### PR TITLE
Add a copy button and navigation to the last batch

### DIFF
--- a/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
@@ -113,8 +113,13 @@ export function SummaryCards({ summaryData, children }: SummaryCardsProps): JSX.
             <CardContent
               variant={rowsByCard}
               label1="Batch ID"
-              value1={batchInfo && abbreviateString(batchInfo?.batchId, 4, 4)}
-              icon1={<CopyButton text={''} />}
+              value1={
+                batchInfo && (
+                  <>
+                    {abbreviateString(batchInfo?.batchId, 6, 4)} <CopyButton text={batchInfo?.batchId || ''} />
+                  </>
+                )
+              }
               loading={isLoading}
               valueSize={valueTextSize}
             />

--- a/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
@@ -8,6 +8,7 @@ import { CardRow } from 'components/common/CardRow'
 import { TotalSummaryResponse } from '.'
 import { abbreviateString } from 'utils'
 import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
+import { CopyButton } from 'components/common/CopyButton'
 
 const BatchInfoHeight = '19.6rem'
 const DESKTOP_TEXT_SIZE = 1.8 // rem
@@ -110,12 +111,14 @@ export function SummaryCards({ summaryData, children }: SummaryCardsProps): JSX.
               valueSize={valueTextSize}
             />
             <CardContent
-              variant="3row"
+              variant={rowsByCard}
               label1="Batch ID"
               value1={batchInfo && abbreviateString(batchInfo?.batchId, 0, 6)}
+              icon1={<CopyButton textToCopy="order-id" contentsToDisplay={''} />}
               loading={isLoading}
               valueSize={valueTextSize}
             />
+            {/*   */}
           </WrapperDoubleContent>
         </WrappedDoubleCard>
         <CardTransactions xs={6} lg={4}>

--- a/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
@@ -9,6 +9,7 @@ import { TotalSummaryResponse } from '.'
 import { abbreviateString } from 'utils'
 import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
 import { CopyButton } from 'components/common/CopyButton'
+import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 
 const BatchInfoHeight = '19.6rem'
 const DESKTOP_TEXT_SIZE = 1.8 // rem
@@ -16,6 +17,10 @@ const MOBILE_TEXT_SIZE = 1.65 // rem
 
 const WrapperCardRow = styled(CardRow)`
   max-width: 70%;
+
+  .copy-text {
+    font-size: 1.4rem;
+  }
 
   ${media.mobile} {
     max-width: 100%;
@@ -116,7 +121,10 @@ export function SummaryCards({ summaryData, children }: SummaryCardsProps): JSX.
               value1={
                 batchInfo && (
                   <>
-                    {abbreviateString(batchInfo?.batchId, 6, 4)} <CopyButton text={batchInfo?.batchId || ''} />
+                    <LinkWithPrefixNetwork to={`/tx/${batchInfo.batchId}`}>
+                      {abbreviateString(batchInfo?.batchId, 6, 4)}
+                    </LinkWithPrefixNetwork>
+                    <CopyButton heightIcon={1.35} text={batchInfo?.batchId || ''} />
                   </>
                 )
               }

--- a/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
@@ -114,7 +114,7 @@ export function SummaryCards({ summaryData, children }: SummaryCardsProps): JSX.
               variant={rowsByCard}
               label1="Batch ID"
               value1={batchInfo && abbreviateString(batchInfo?.batchId, 0, 6)}
-              icon1={<CopyButton textToCopy="order-id" contentsToDisplay={''} />}
+              icon1={<CopyButton text={''} />}
               loading={isLoading}
               valueSize={valueTextSize}
             />

--- a/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
@@ -113,7 +113,7 @@ export function SummaryCards({ summaryData, children }: SummaryCardsProps): JSX.
             <CardContent
               variant={rowsByCard}
               label1="Batch ID"
-              value1={batchInfo && abbreviateString(batchInfo?.batchId, 0, 6)}
+              value1={batchInfo && abbreviateString(batchInfo?.batchId, 4, 4)}
               icon1={<CopyButton text={''} />}
               loading={isLoading}
               valueSize={valueTextSize}

--- a/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
@@ -118,7 +118,6 @@ export function SummaryCards({ summaryData, children }: SummaryCardsProps): JSX.
               loading={isLoading}
               valueSize={valueTextSize}
             />
-            {/*   */}
           </WrapperDoubleContent>
         </WrappedDoubleCard>
         <CardTransactions xs={6} lg={4}>

--- a/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
@@ -18,10 +18,6 @@ const MOBILE_TEXT_SIZE = 1.65 // rem
 const WrapperCardRow = styled(CardRow)`
   max-width: 70%;
 
-  .copy-text {
-    font-size: 1.4rem;
-  }
-
   ${media.mobile} {
     max-width: 100%;
   }

--- a/src/components/common/Card/CardContent.tsx
+++ b/src/components/common/Card/CardContent.tsx
@@ -52,6 +52,10 @@ const CardBody = styled.div<{
       justify-content: ${({ variant, direction }): string =>
         variant === 'double' && direction === 'row' ? 'flex-end' : 'center'};
       width: ${({ labelWidth }): string => (labelWidth ? `${labelWidth}px` : 'initial')};
+      flex-direction: row-reverse;
+      span {
+        padding-left: 0.5rem;
+      }
     }
     > div {
       display: flex;

--- a/src/components/common/Card/CardContent.tsx
+++ b/src/components/common/Card/CardContent.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import ShimmerBar from 'apps/explorer/components/common/ShimmerBar'
+import { media } from 'theme/styles/media'
 
 export type statusType = 'success' | 'danger'
 
@@ -67,6 +68,9 @@ const CardBody = styled.div<{
       > h3 {
         font-size: ${({ valueSize }): number => valueSize || 1.8}rem;
         margin: 0px;
+        ${media.mobile} {
+          font-size: 1.45rem;
+        }
       }
       > span {
         font-weight: bold;

--- a/src/components/common/Card/CardContent.tsx
+++ b/src/components/common/Card/CardContent.tsx
@@ -10,7 +10,7 @@ export interface CardContentProps {
   direction?: string
   icon1?: React.ReactElement
   label1: string
-  value1: string | number | undefined
+  value1: string | number | undefined | React.ReactElement
   valueSize?: number
   labelWidth?: number
   caption1?: string | number

--- a/src/components/common/Card/CardContent.tsx
+++ b/src/components/common/Card/CardContent.tsx
@@ -130,8 +130,8 @@ export const CardContent: React.FC<CardContentProps> = ({
       {!loading && label2 && (
         <div>
           <p>
-            {icon2 && <React.Fragment>{icon2} &nbsp;</React.Fragment>}
             {label2}
+            {icon2 && <React.Fragment>{icon2} &nbsp;</React.Fragment>}
           </p>
           <div>
             <h3>{value2}</h3>

--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -20,6 +20,7 @@ const Icon = styled(FontAwesomeIcon)<{ copied?: string; height?: number }>`
   cursor: ${({ copied }): string => (copied ? 'reset' : 'pointer')};
   vertical-align: baseline;
   margin: 0 0 0 0.3rem;
+  width: 1.6rem !important;
 
   ${({ height }): FlattenSimpleInterpolation | undefined | number =>
     height &&
@@ -46,12 +47,6 @@ const Icon = styled(FontAwesomeIcon)<{ copied?: string; height?: number }>`
       display: none;
     }
   }
-`
-
-const Wrapper = styled.span`
-  width: 1.6rem;
-  height: 1.6rem;
-  display: inline-block;
 `
 
 export type Props = { text: string; onCopy?: (value: string) => void; heightIcon?: number }
@@ -87,10 +82,10 @@ export function CopyButton(props: Props): JSX.Element {
 
   return (
     <CopyToClipboard text={text} onCopy={handleOnCopy}>
-      <Wrapper>
+      <span>
         <Icon height={heightIcon} icon={copied ? faCheck : faCopy} copied={copied ? 'true' : undefined} />{' '}
         {copied && <span className="copy-text">Copied</span>}
-      </Wrapper>
+      </span>
     </CopyToClipboard>
   )
 }

--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import CopyToClipboard from 'react-copy-to-clipboard'
 
 import { DISPLAY_TEXT_COPIED_CHECK } from 'apps/explorer/const'
+import { media } from 'theme/styles/media'
 
 // Why is `copied` not a boolean?
 //   Because it's passed down to parent component (`FontAwesomeIcon`) and
@@ -33,7 +34,17 @@ const Icon = styled(FontAwesomeIcon)<{ copied?: string; height?: number }>`
   + span {
     color: ${({ theme }): string => theme.green};
     font-weight: ${({ theme }): string => theme.fontMedium};
-    margin: 0 0 0 0.1rem;
+    font-size: 1.2rem;
+    position: absolute;
+    border: 1px solid ${({ theme }): string => theme.green};
+    background-color: ${({ theme }): string => theme.green2};
+    padding: 0.5rem;
+    border-radius: 0.4rem;
+    margin-top: -3rem;
+    margin-left: -3.3rem;
+    ${media.mediumDownMd} {
+      display: none;
+    }
   }
 `
 

--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -17,7 +17,8 @@ const Icon = styled(FontAwesomeIcon)<{ copied?: string; height?: number }>`
   color: ${({ theme, copied }): string => (copied ? theme.green : theme.grey)};
   transition: color 0.2s ease-in;
   cursor: ${({ copied }): string => (copied ? 'reset' : 'pointer')};
-  vertical-align: top;
+  vertical-align: baseline;
+  margin: 0 0 0 0.3rem;
 
   ${({ height }): FlattenSimpleInterpolation | undefined | number =>
     height &&

--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -16,7 +16,7 @@ import { media } from 'theme/styles/media'
 //   Effectively though, it's treated as a boolean, thus the value doesn't matter
 const Icon = styled(FontAwesomeIcon)<{ copied?: string; height?: number }>`
   color: ${({ theme, copied }): string => (copied ? theme.green : theme.grey)};
-  transition: color 0.2s ease-in;
+  transition: color 0.1s ease-in;
   cursor: ${({ copied }): string => (copied ? 'reset' : 'pointer')};
   vertical-align: baseline;
   margin: 0 0 0 0.3rem;
@@ -46,6 +46,12 @@ const Icon = styled(FontAwesomeIcon)<{ copied?: string; height?: number }>`
       display: none;
     }
   }
+`
+
+const Wrapper = styled.span`
+  width: 1.6rem;
+  height: 1.6rem;
+  display: inline-block;
 `
 
 export type Props = { text: string; onCopy?: (value: string) => void; heightIcon?: number }
@@ -81,10 +87,10 @@ export function CopyButton(props: Props): JSX.Element {
 
   return (
     <CopyToClipboard text={text} onCopy={handleOnCopy}>
-      <span>
+      <Wrapper>
         <Icon height={heightIcon} icon={copied ? faCheck : faCopy} copied={copied ? 'true' : undefined} />{' '}
         {copied && <span className="copy-text">Copied</span>}
-      </span>
+      </Wrapper>
     </CopyToClipboard>
   )
 }

--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import styled from 'styled-components'
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import { faCopy } from '@fortawesome/free-regular-svg-icons'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -13,11 +13,17 @@ import { DISPLAY_TEXT_COPIED_CHECK } from 'apps/explorer/const'
 //   Which does not like to receive boolean values, with an error like:
 // "Warning: Received `false` for a non-boolean attribute `copied`"
 //   Effectively though, it's treated as a boolean, thus the value doesn't matter
-const Icon = styled(FontAwesomeIcon)<{ copied?: string }>`
+const Icon = styled(FontAwesomeIcon)<{ copied?: string; height?: number }>`
   color: ${({ theme, copied }): string => (copied ? theme.green : theme.grey)};
   transition: color 0.2s ease-in;
   cursor: ${({ copied }): string => (copied ? 'reset' : 'pointer')};
   vertical-align: top;
+
+  ${({ height }): FlattenSimpleInterpolation | undefined | number =>
+    height &&
+    css`
+      height: ${height}rem;
+    `}
 
   &:hover {
     color: ${({ theme, copied }): string => (copied ? theme.green : theme.white)};
@@ -30,7 +36,7 @@ const Icon = styled(FontAwesomeIcon)<{ copied?: string }>`
   }
 `
 
-export type Props = { text: string; onCopy?: (value: string) => void }
+export type Props = { text: string; onCopy?: (value: string) => void; heightIcon?: number }
 
 /**
  * Simple CopyButton component.
@@ -41,7 +47,7 @@ export type Props = { text: string; onCopy?: (value: string) => void }
  * then is back to original copy icon
  */
 export function CopyButton(props: Props): JSX.Element {
-  const { text, onCopy } = props
+  const { text, onCopy, heightIcon } = props
 
   const [copied, setCopied] = useState(false)
   const handleOnCopy = (): void => {
@@ -64,7 +70,7 @@ export function CopyButton(props: Props): JSX.Element {
   return (
     <CopyToClipboard text={text} onCopy={handleOnCopy}>
       <span>
-        <Icon icon={copied ? faCheck : faCopy} copied={copied ? 'true' : undefined} />{' '}
+        <Icon height={heightIcon} icon={copied ? faCheck : faCopy} copied={copied ? 'true' : undefined} />{' '}
         {copied && <span className="copy-text">Copied</span>}
       </span>
     </CopyToClipboard>

--- a/src/components/common/RowWithCopyButton/index.tsx
+++ b/src/components/common/RowWithCopyButton/index.tsx
@@ -16,6 +16,7 @@ const Wrapper = styled.span`
 
 const Content = styled.div`
   display: inline-block;
+  position: relative;
 `
 
 type Props = {

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -82,7 +82,7 @@ const Wrapper = styled(StyledUserDetailsTable)`
         align-items: center;
       }
       .copy-text {
-        margin-left: 5px;
+        display: none;
       }
     }
   }

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -83,7 +83,7 @@ const Wrapper = styled(StyledUserDetailsTable)`
         align-items: center;
       }
       .copy-text {
-        margin-left: 5px;
+        display: none;
       }
     }
   }


### PR DESCRIPTION
# Summary
Closes #66 
![image](https://user-images.githubusercontent.com/622217/164341394-5e836efe-c72c-4981-9da8-9f4b3661c7a0.png)
Extra changes: 
- Address format with 6 + 4 digits 0x0003...e29c (according format in others sections.)
- Improvements to the Copy button tooltip. Now the "Copied" message appears as a tooltip (texts moving prevented).
![image](https://user-images.githubusercontent.com/622217/164342429-4330674c-cb6e-41a0-92c8-b9487f9bd684.png)
