### PR TITLE
[Batch Viewer] Fix multiple AMM's interactions not visible

### DIFF
--- a/src/apps/explorer/components/TransanctionBatchGraph/elementsBuilder.tsx
+++ b/src/apps/explorer/components/TransanctionBatchGraph/elementsBuilder.tsx
@@ -49,7 +49,7 @@ export default class ElementsBuilder {
     this._edges.push({
       group: 'edges',
       data: {
-        id: `${source.type}:${source.id}->${target.type}:${target.id}`,
+        id: `${source.type}:${source.id}->${label}->${target.type}:${target.id}`,
         source: `${source.type}:${source.id}`,
         target: `${target.type}:${target.id}`,
         label,

--- a/src/apps/explorer/components/TransanctionBatchGraph/styled.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/styled.ts
@@ -25,7 +25,7 @@ export function STYLESHEET(theme: DefaultTheme): Stylesheet[] {
         width: 2,
         'target-arrow-shape': 'triangle',
         'target-arrow-color': theme.grey,
-        'curve-style': 'unbundled-bezier',
+        'curve-style': 'bezier',
         color: theme.black,
         'line-color': theme.grey,
         'line-opacity': 0.8,


### PR DESCRIPTION
# Summary

Closes #72 

<img width="600" alt="image" src="https://user-images.githubusercontent.com/3328006/166237356-114b566b-4b27-4260-a33a-5bbbd4dfb484.png">


# To Test
Open the Batch Viewer in https://pr78--gpui.review.gnosisdev.com/tx/0x8bb4f9644bdf19684d66c55133ded17c198e36069a502f903311eb07ed978145 and there should be multiple interactions in the Balancer's Vault