### PR TITLE
Volume chart improvements

### DIFF
--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
@@ -82,7 +82,7 @@ export const ContainerTitle = styled.span<{ captionColor?: 'green' | 'red1' | 'g
   position: absolute;
   top: 1rem;
   left: 1rem;
-  z-index: 4;
+  z-index: 3;
   > h3 {
     color: ${({ theme }): string => theme.grey};
     font-size: small;
@@ -146,14 +146,19 @@ export const StyledShimmerBar = styled(ShimmerBar)`
   min-width: 10rem;
 `
 
-export const WrapperTooltipPrice = styled.div`
+export const WrapperTooltipPrice = styled.div<{ left: number; top: number; height?: number; width?: number }>`
   color: ${({ theme }): string => theme.white};
   background-color: ${({ theme }): string => theme.bg1};
   border: 1px solid ${({ theme }): string => theme.bg2};
   padding: 0.5rem 1rem;
-  border-radius: 0.4rem;
-  margin: 0 0.5rem;
-  z-index: 3;
+  border-radius: 0.5rem;
+  margin: 0;
+  z-index: 2;
+  position: absolute;
+  left: ${({ left }): string => `${left}px`};
+  top: ${({ top }): string => `${top}px`};
+  height: ${({ height = 64 }): string => `${height}px`};
+  width: ${({ width = 140 }): string => `${width}px`};
 
   > h4 {
     font-size: large;

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
@@ -1,4 +1,4 @@
-import styled, { keyframes, FlattenSimpleInterpolation, css } from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 
 import { media } from 'theme/styles/media'
 import GraphSkeleton from 'assets/img/graph-skeleton.svg'
@@ -78,11 +78,11 @@ export const WrapperChart = styled.div`
   }
 `
 
-export const ContainerTitle = styled.span<{ captionColor?: 'green' | 'red1' | 'grey'; dateStyle?: boolean }>`
+export const ContainerTitle = styled.span<{ captionColor?: 'green' | 'red1' | 'grey' }>`
   position: absolute;
   top: 1rem;
   left: 1rem;
-  z-index: 3;
+  z-index: 4;
   > h3 {
     color: ${({ theme }): string => theme.grey};
     font-size: small;
@@ -97,13 +97,6 @@ export const ContainerTitle = styled.span<{ captionColor?: 'green' | 'red1' | 'g
     gap: 1rem;
     align-items: center;
 
-    ${({ dateStyle }): FlattenSimpleInterpolation | undefined | false =>
-      dateStyle &&
-      css`
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0rem;
-      `}
     > p {
       color: ${({ theme }): string => theme.white};
       font-size: large;
@@ -151,4 +144,27 @@ export const WrapperPeriodButton = styled.button<{ active: boolean }>`
 export const StyledShimmerBar = styled(ShimmerBar)`
   margin: 1.2rem 0;
   min-width: 10rem;
+`
+
+export const WrapperTooltipPrice = styled.div`
+  color: ${({ theme }): string => theme.white};
+  background-color: ${({ theme }): string => theme.bg1};
+  border: 1px solid ${({ theme }): string => theme.bg2};
+  padding: 0.5rem 1rem;
+  border-radius: 0.4rem;
+  margin: 0 0.5rem;
+  z-index: 3;
+
+  > h4 {
+    font-size: large;
+    font-weight: ${({ theme }): string => theme.fontMedium};
+    margin: 1rem 0;
+    color: ${({ theme }): string => theme.white};
+  }
+
+  > p {
+    color: ${({ theme }): string => theme.grey};
+    font-size: 1.1rem;
+    padding: 0;
+  }
 `

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
@@ -73,8 +73,8 @@ export const WrapperChart = styled.div`
   }
 
   canvas {
-    top: 2rem !important;
-    height: calc(100% - 2rem) !important;
+    top: 5rem !important;
+    height: calc(100% - 5rem) !important;
   }
 `
 

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
@@ -73,8 +73,14 @@ export const WrapperChart = styled.div`
   }
 
   canvas {
-    top: 5rem !important;
-    height: calc(100% - 5rem) !important;
+    top: 3rem !important;
+    height: calc(100% - 3rem) !important;
+  }
+  ${media.mobile} {
+    canvas {
+      top: 5rem !important;
+      height: calc(100% - 5rem) !important;
+    }
   }
 `
 
@@ -88,6 +94,13 @@ export const ContainerTitle = styled.span<{ captionColor?: 'green' | 'red1' | 'g
     font-size: small;
     font-weight: ${({ theme }): string => theme.fontMedium};
     margin: 0;
+    ${media.mobile} {
+      top: 0.5rem;
+      word-wrap: break-word;
+      max-width: 13rem;
+      line-height: 1.1;
+      font-size: x-small;
+    }
   }
 
   > span {
@@ -109,6 +122,9 @@ export const ContainerTitle = styled.span<{ captionColor?: 'green' | 'red1' | 'g
         margin: -1rem 0;
         color: ${({ theme }): string => theme.grey};
         font-size: 1.1rem;
+      }
+      ${media.mobile} {
+        font-size: small;
       }
     }
   }

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled.ts
@@ -161,7 +161,7 @@ export const WrapperTooltipPrice = styled.div<{ left: number; top: number; heigh
   width: ${({ width = 140 }): string => `${width}px`};
 
   > h4 {
-    font-size: large;
+    font-size: 1.5rem;
     font-weight: ${({ theme }): string => theme.fontMedium};
     margin: 1rem 0;
     color: ${({ theme }): string => theme.white};

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -9,6 +9,7 @@ import {
   UTCTimestamp,
   BarPrice,
   Coordinate,
+  LogicalRange,
 } from 'lightweight-charts'
 
 import { formatSmart } from 'utils'
@@ -43,6 +44,7 @@ export interface VolumeChartProps {
   height?: number
   width?: number
   period?: VolumePeriod
+  logicalTimeScaleRange?: LogicalRange | undefined
 }
 
 export function PeriodButton({
@@ -103,6 +105,7 @@ function _buildChart(
     },
     timeScale: {
       visible: false,
+      minBarSpacing: 0,
     },
     grid: {
       horzLines: {
@@ -195,6 +198,7 @@ export function VolumeChart({
   width = undefined,
   period,
   children,
+  logicalTimeScaleRange,
 }: React.PropsWithChildren<VolumeChartProps>): JSX.Element {
   const { data: items, currentVolume, changedVolume, isLoading } = volumeData || {}
   const chartContainerRef = useRef<HTMLDivElement>(null)
@@ -244,9 +248,11 @@ export function VolumeChart({
       setCrossHairData({ time, value, coordinates: { top: coordinate, left: shiftedCoordinate } })
     })
 
-    chart.timeScale().fitContent()
+    logicalTimeScaleRange
+      ? chart.timeScale().setVisibleLogicalRange(logicalTimeScaleRange)
+      : chart.timeScale().fitContent()
     setChartCreated(chart)
-  }, [captionNameColor, chartCreated, height, isLoading, items, theme, width])
+  }, [captionNameColor, chartCreated, height, isLoading, items, logicalTimeScaleRange, theme, width])
 
   // resize when window width change
   useEffect(() => {

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -22,8 +22,8 @@ import {
   StyledShimmerBar,
   WrapperTooltipPrice,
 } from 'apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled'
-import { VolumePeriod } from './VolumeChartWidget'
-import { numberFormatter } from '../utils'
+import { VolumePeriod } from 'apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget'
+import { numberFormatter } from 'apps/explorer/components/SummaryCardsWidget/utils'
 import { useNetworkId } from 'state/network'
 
 const DEFAULT_CHART_HEIGHT = 196 // px
@@ -157,19 +157,23 @@ const PriceTooltip = ({
       _format = 'MMM d HH:mm, yyyy'
     }
 
-    return format(fromUnixTime(time as UTCTimestamp), _format)
+    return format(fromUnixTime(time), _format)
   }, [period, time])
 
   if (!value || !containerWidth || !coordinates) return null
 
   const TOOLTIP_WIDTH = 140 // px
   const TOOLTIP_HEIGHT = 64 // px
-  const TOOLTIP_MARGIN = 15 // px
-  const leftPosition = Math.max(0, Math.min(containerWidth - (TOOLTIP_WIDTH + TOOLTIP_MARGIN), coordinates.left))
+  const H_TOOLTIP_MARGIN = 15 // px
+  const V_TOOLTIP_MARGIN = 50 // px
+  const leftPosition = Math.max(
+    H_TOOLTIP_MARGIN,
+    Math.min(containerWidth - (TOOLTIP_WIDTH + H_TOOLTIP_MARGIN), coordinates.left),
+  )
   const topPosition =
-    coordinates.top - TOOLTIP_HEIGHT - TOOLTIP_MARGIN > 0
-      ? coordinates.top - TOOLTIP_HEIGHT - TOOLTIP_MARGIN
-      : Math.max(0, Math.min(containerWidth - TOOLTIP_HEIGHT - TOOLTIP_MARGIN, coordinates.top + TOOLTIP_MARGIN))
+    coordinates.top - TOOLTIP_HEIGHT - V_TOOLTIP_MARGIN > 0
+      ? coordinates.top - TOOLTIP_HEIGHT - H_TOOLTIP_MARGIN
+      : Math.max(0, Math.min(containerWidth - TOOLTIP_HEIGHT - H_TOOLTIP_MARGIN, coordinates.top + H_TOOLTIP_MARGIN))
 
   return (
     <WrapperTooltipPrice left={leftPosition} top={topPosition} width={TOOLTIP_WIDTH} height={TOOLTIP_HEIGHT}>
@@ -225,11 +229,10 @@ export function VolumeChart({
         return
       }
 
-      const OFFSET_SPACE = 50
       const value = param.seriesPrices.get(series) as BarPrice
       const time = param.time as UTCTimestamp
       const coordinate = series.priceToCoordinate(value) || (0 as Coordinate)
-      const shiftedCoordinate = param.point.x - OFFSET_SPACE
+      const shiftedCoordinate = param.point.x
       setCrossHairData({ time, value, coordinates: { top: coordinate, left: shiftedCoordinate } })
     })
 

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -162,10 +162,10 @@ const PriceTooltip = ({
 
   if (!value || !containerWidth || !coordinates) return null
 
-  const TOOLTIP_WIDTH = 140 // px
-  const TOOLTIP_HEIGHT = 64 // px
+  const TOOLTIP_WIDTH = 130 // px
+  const TOOLTIP_HEIGHT = 54 // px
   const H_TOOLTIP_MARGIN = 15 // px
-  const V_TOOLTIP_MARGIN = 50 // px
+  const V_TOOLTIP_MARGIN = 60 // px
   const leftPosition = Math.max(
     H_TOOLTIP_MARGIN,
     Math.min(containerWidth - (TOOLTIP_WIDTH + H_TOOLTIP_MARGIN), coordinates.left),

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -22,7 +22,10 @@ import {
   StyledShimmerBar,
   WrapperTooltipPrice,
 } from 'apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.styled'
-import { VolumePeriod } from 'apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget'
+import {
+  VolumePeriod,
+  volumePeriodTitle,
+} from 'apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget'
 import { numberFormatter } from 'apps/explorer/components/SummaryCardsWidget/utils'
 import { useNetworkId } from 'state/network'
 
@@ -173,7 +176,10 @@ const PriceTooltip = ({
   const topPosition =
     coordinates.top - TOOLTIP_HEIGHT - V_TOOLTIP_MARGIN > 0
       ? coordinates.top - TOOLTIP_HEIGHT - H_TOOLTIP_MARGIN
-      : Math.max(0, Math.min(containerWidth - TOOLTIP_HEIGHT - H_TOOLTIP_MARGIN, coordinates.top + H_TOOLTIP_MARGIN))
+      : Math.max(
+          V_TOOLTIP_MARGIN,
+          Math.min(containerWidth - TOOLTIP_HEIGHT - H_TOOLTIP_MARGIN, coordinates.top + H_TOOLTIP_MARGIN),
+        )
 
   return (
     <WrapperTooltipPrice left={leftPosition} top={topPosition} width={TOOLTIP_WIDTH} height={TOOLTIP_HEIGHT}>
@@ -200,6 +206,7 @@ export function VolumeChart({
   const network = useNetworkId()
   const previousPeriod = usePreviousLastValueData(period)
   const previousNetwork = usePreviousLastValueData(network)
+  const periodTitle = period && volumePeriodTitle.get(period)
 
   // reset the chart when the volume/network period is changed
   useEffect(() => {
@@ -238,7 +245,6 @@ export function VolumeChart({
     })
 
     chart.timeScale().fitContent()
-    console.log(chart.timeScale().getVisibleLogicalRange())
     setChartCreated(chart)
   }, [captionNameColor, chartCreated, height, isLoading, items, theme, width])
 
@@ -261,7 +267,7 @@ export function VolumeChart({
     <>
       <WrapperChart ref={chartContainerRef}>
         <ContainerTitle captionColor={captionNameColor}>
-          <h3>CoW Protocol volume</h3>
+          <h3>CoW Protocol {periodTitle} volume</h3>
           <span>
             {isLoading ? (
               <StyledShimmerBar height={2} />

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -206,6 +206,7 @@ export function VolumeChart({
     if ((period !== previousPeriod || network !== previousNetwork) && chartCreated) {
       chartCreated.resize(0, 0)
       setChartCreated(null)
+      setCrossHairData(null)
     }
   }, [chartCreated, period, previousPeriod, network, previousNetwork])
 
@@ -237,6 +238,7 @@ export function VolumeChart({
     })
 
     chart.timeScale().fitContent()
+    console.log(chart.timeScale().getVisibleLogicalRange())
     setChartCreated(chart)
   }, [captionNameColor, chartCreated, height, isLoading, items, theme, width])
 

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -155,6 +155,7 @@ const PriceTooltip = ({
   containerWidth: number | undefined
 }): JSX.Element | null => {
   const { time, value, coordinates } = crossHairData || {}
+  const isTopCoordinateValid = coordinates && coordinates.top > 1
   const formattedDate = React.useMemo(() => {
     if (!time) return ''
 
@@ -166,7 +167,7 @@ const PriceTooltip = ({
     return format(fromUnixTime(time), _format)
   }, [period, time])
 
-  if (!value || !containerWidth || !coordinates) return null
+  if (!value || !containerWidth || !coordinates || !isTopCoordinateValid) return null
 
   const TOOLTIP_WIDTH = 130 // px
   const TOOLTIP_HEIGHT = 54 // px

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget.tsx
@@ -21,6 +21,10 @@ export const volumePeriodTitle = new Map(
   ]),
 )
 
+const logicalTimeRange = {
+  [VolumePeriod.WEEKLY]: { from: 3.4, to: 9 }, // by the 7 points
+}
+
 export function VolumeChartWidget(): JSX.Element {
   const [periodSelected, setVolumeTimePeriod] = useState(VolumePeriod.DAILY)
   const volumeData = useGetVolumeData(periodSelected)
@@ -43,7 +47,12 @@ export function VolumeChartWidget(): JSX.Element {
 
   return (
     <WrapperVolumeChart ref={containerRef}>
-      <VolumeChart volumeData={volumeData} width={width} period={periodSelected}>
+      <VolumeChart
+        volumeData={volumeData}
+        width={width}
+        period={periodSelected}
+        logicalTimeScaleRange={logicalTimeRange[periodSelected]}
+      >
         <PeriodButton
           isLoading={volumeData?.isLoading}
           active={periodSelected === VolumePeriod.DAILY}

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget.tsx
@@ -14,6 +14,13 @@ export enum VolumePeriod {
   YEARLY = '1Y',
 }
 
+export const volumePeriodTitle = new Map(
+  (Object.keys(VolumePeriod) as (keyof typeof VolumePeriod)[]).map((key) => [
+    VolumePeriod[key],
+    key.toLocaleLowerCase(),
+  ]),
+)
+
 export function VolumeChartWidget(): JSX.Element {
   const [periodSelected, setVolumeTimePeriod] = useState(VolumePeriod.DAILY)
   const volumeData = useGetVolumeData(periodSelected)

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget.tsx
@@ -21,6 +21,9 @@ export const volumePeriodTitle = new Map(
   ]),
 )
 
+/* A lightweight-charts logical range is an object with: 'from' and 'to', which are numbers and represent
+ * logical indexes on the thweight-charts time scale.
+ */
 const logicalTimeRange = {
   [VolumePeriod.WEEKLY]: { from: 3.4, to: 9 }, // by the 7 points
 }


### PR DESCRIPTION
# Summary

Closes #87 


- [x] 2. Update the current CoW Protocol volume to reflect the selected period, i.e. Daily volume, Monthly volume, etc
- ~~3. Add a Total Volume card~~ [PR#90](https://github.com/cowprotocol/explorer/pull/90)
- [x] 4. Add a tooltip with the selected volume and date values
- ~~5. Make the volume chart bigger so the tooltip is correctly displayed. Make it occupy the whole cards width~~ [PR#90](https://github.com/cowprotocol/explorer/pull/90)
- [x] 6. Remove the green/red chart colors which causes confusion. Use a neutral color, the main orange is a good option
- [x] 7. Remove the current x-axis at the current volume value
- [x] 8. Add the x-axis to the hover state, keep the y-axis too

### :warning:  Note
 - The tasks 3 and 5 will be drive on [PR#90](https://github.com/cowprotocol/explorer/pull/90)
 (https://github.com/cowprotocol/explorer/pull/90)
![image](https://user-images.githubusercontent.com/622217/168149526-15ead239-54cc-481e-aea1-9b9f4c2ebc8e.png)