### PR TITLE
Adding surplus column on tx table

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -216,7 +216,7 @@ type BaseTooltipsProps = RequireAtLeastOne<
   'sourceIconSvg' | 'targetContent'
 >
 
-export const BaseIconTooltip: React.FC<BaseTooltipsProps> = ({
+export const BaseIconTooltipOnClick: React.FC<BaseTooltipsProps> = ({
   tooltip,
   placement = 'top',
   offset,
@@ -246,6 +246,23 @@ export const BaseIconTooltip: React.FC<BaseTooltipsProps> = ({
   )
 }
 
+export const BaseIconTooltipOnHover: React.FC<BaseTooltipsProps> = ({
+  tooltip,
+  placement = 'top',
+  offset,
+  sourceIconSvg,
+  targetContent,
+}) => {
+  const { tooltipProps, targetProps } = usePopperDefault<HTMLSpanElement>(placement, offset)
+
+  return (
+    <>
+      <HelperSpan {...targetProps}>{sourceIconSvg ? <CustomSvgIcon src={sourceIconSvg} /> : targetContent}</HelperSpan>
+      <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
+    </>
+  )
+}
+
 type HelpTooltipProps = Omit<BaseTooltipsProps, 'sourceIconSvg' | 'targetContent'>
 
 const HelperSpan = styled.span`
@@ -270,5 +287,5 @@ export const HelpTooltipContainer = styled(LongTooltipContainer)`
 `
 
 export const HelpTooltip: React.FC<HelpTooltipProps> = ({ tooltip, placement = 'top', offset }) => {
-  return <BaseIconTooltip sourceIconSvg={questionImg} tooltip={tooltip} placement={placement} offset={offset} />
+  return <BaseIconTooltipOnClick sourceIconSvg={questionImg} tooltip={tooltip} placement={placement} offset={offset} />
 }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -247,3 +247,46 @@ export const HelpTooltip: React.FC<HelpTooltipProps> = ({ tooltip, placement = '
     </>
   )
 }
+
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
+  }[Keys]
+
+type BaseTooltipsProps = RequireAtLeastOne<
+  HelpTooltipProps & {
+    sourceIconSvg?: string
+    targetContent?: ReactNode
+  },
+  'sourceIconSvg' | 'targetContent'
+>
+
+export const BaseIconTooltip: React.FC<BaseTooltipsProps> = ({
+  tooltip,
+  placement = 'top',
+  offset,
+  sourceIconSvg,
+  targetContent,
+}) => {
+  const {
+    targetProps: { ref, onClick },
+    tooltipProps,
+  } = usePopperOnClick<HTMLSpanElement>(placement, offset)
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLSpanElement>) => {
+      e.stopPropagation()
+      onClick()
+    },
+    [onClick],
+  )
+
+  return (
+    <>
+      <HelperSpan ref={ref} onClick={handleClick}>
+        {sourceIconSvg ? <QuestionIcon src={sourceIconSvg} /> : targetContent}
+      </HelperSpan>
+      <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
+    </>
+  )
+}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -13,7 +13,7 @@ import Portal from 'components/Portal'
 // hooks
 import { usePopperOnClick, usePopperDefault, TOOLTIP_OFFSET } from 'hooks/usePopper'
 
-const QuestionIcon = styled(SVG)`
+const CustomSvgIcon = styled(SVG)`
   width: 1.4rem;
   height: 1.4rem;
   fill: ${({ theme }): string => theme.grey};
@@ -200,61 +200,16 @@ export const LongTooltipContainer = styled.div`
   line-height: 1.4;
 `
 
-interface HelpTooltipProps {
-  tooltip: ReactNode
-  placement?: Placement
-  offset?: number
-}
-
-const HelperSpan = styled.span`
-  cursor: pointer;
-  transition: color 0.1s;
-  display: flex;
-  padding: 0 0.6rem 0 0;
-
-  :hover {
-    color: #748a47;
-  }
-`
-
-export const HelpTooltipContainer = styled(LongTooltipContainer)`
-  font-size: 1.6rem;
-  font-family: monospace;
-  padding: 1em;
-  color: black;
-`
-
-export const HelpTooltip: React.FC<HelpTooltipProps> = ({ tooltip, placement = 'top', offset }) => {
-  const {
-    targetProps: { ref, onClick },
-    tooltipProps,
-  } = usePopperOnClick<HTMLSpanElement>(placement, offset)
-
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLSpanElement>) => {
-      e.stopPropagation()
-      onClick()
-    },
-    [onClick],
-  )
-
-  return (
-    <>
-      <HelperSpan ref={ref} onClick={handleClick}>
-        <QuestionIcon src={questionImg} />
-      </HelperSpan>
-      <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
-    </>
-  )
-}
-
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
   {
     [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
   }[Keys]
 
 type BaseTooltipsProps = RequireAtLeastOne<
-  HelpTooltipProps & {
+  {
+    tooltip: ReactNode
+    placement?: Placement
+    offset?: number
     sourceIconSvg?: string
     targetContent?: ReactNode
   },
@@ -284,9 +239,36 @@ export const BaseIconTooltip: React.FC<BaseTooltipsProps> = ({
   return (
     <>
       <HelperSpan ref={ref} onClick={handleClick}>
-        {sourceIconSvg ? <QuestionIcon src={sourceIconSvg} /> : targetContent}
+        {sourceIconSvg ? <CustomSvgIcon src={sourceIconSvg} /> : targetContent}
       </HelperSpan>
       <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
     </>
   )
+}
+
+type HelpTooltipProps = Omit<BaseTooltipsProps, 'sourceIconSvg' | 'targetContent'>
+
+const HelperSpan = styled.span`
+  cursor: pointer;
+  transition: color 0.1s;
+  display: flex;
+  padding: 0 0.6rem 0 0;
+
+  .default-icon-tooltip {
+    color: ${({ theme }): string => theme.grey};
+    :hover {
+      color: ${({ theme }): string => theme.white};
+    }
+  }
+`
+
+export const HelpTooltipContainer = styled(LongTooltipContainer)`
+  font-size: 1.6rem;
+  font-family: monospace;
+  padding: 1em;
+  color: black;
+`
+
+export const HelpTooltip: React.FC<HelpTooltipProps> = ({ tooltip, placement = 'top', offset }) => {
+  return <BaseIconTooltip sourceIconSvg={questionImg} tooltip={tooltip} placement={placement} offset={offset} />
 }

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -8,8 +8,11 @@ import { formatSmart, formatSmartMaxPrecision, safeTokenName } from 'utils'
 import { LOW_PRECISION_DECIMALS, PERCENTAGE_PRECISION } from 'apps/explorer/const'
 import { Tooltip } from 'components/Tooltip'
 import { usePopperOnClick } from 'hooks/usePopper'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faThumbsUp as faIcon } from '@fortawesome/free-regular-svg-icons'
 
 const Wrapper = styled.div`
+  display: flex;
   & > * {
     margin-right: 0.25rem;
   }
@@ -78,6 +81,16 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
   )
 }
 
+const IconWrapper = styled(FontAwesomeIcon)`
+  padding: 0.6rem;
+  margin: -0.6rem 0 -0.6rem -0.6rem;
+  box-sizing: content-box;
+
+  :hover {
+    cursor: pointer;
+  }
+`
+
 export function OrderSurplusTooltipDisplay(props: Props): JSX.Element | null {
   const { amount, percentage } = useGetSurplus(props)
   const tooltipPlacement = 'top'
@@ -86,12 +99,15 @@ export function OrderSurplusTooltipDisplay(props: Props): JSX.Element | null {
   if (amount === undefined || percentage === undefined) return null
 
   return (
-    <Wrapper>
+    <span className="wrap-datedisplay">
       <Tooltip {...tooltipProps}>{amount}</Tooltip>
-      <Surplus className="span-inside-tooltip" {...targetProps}>
-        {percentage}
-      </Surplus>
-      {/* <UsdAmount>(~${formattedUsdAmount})</UsdAmount> */}
-    </Wrapper>
+      <Wrapper>
+        <span {...targetProps}>
+          <IconWrapper icon={faIcon} />
+          <Surplus>{percentage}</Surplus>
+        </span>
+        {/* <UsdAmount>(~${formattedUsdAmount})</UsdAmount> */}
+      </Wrapper>
+    </span>
   )
 }

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -30,7 +30,7 @@ const Surplus = styled.span`
 //   opacity: 0.5;
 // `
 
-export type Props = { order: Order; amountLikeTooltip?: boolean }
+export type Props = { order: Order }
 type SurplusText = { amount: string; percentage: string }
 
 function useGetSurplus(props: Props): SurplusText {

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -6,8 +6,7 @@ import { Order } from 'api/operator'
 import { formatSmart, formatSmartMaxPrecision, safeTokenName } from 'utils'
 
 import { LOW_PRECISION_DECIMALS, PERCENTAGE_PRECISION } from 'apps/explorer/const'
-import { Tooltip } from 'components/Tooltip'
-import { usePopperOnClick } from 'hooks/usePopper'
+import { BaseIconTooltip } from 'components/Tooltip'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faThumbsUp as faIcon } from '@fortawesome/free-regular-svg-icons'
 
@@ -93,21 +92,18 @@ const IconWrapper = styled(FontAwesomeIcon)`
 
 export function OrderSurplusTooltipDisplay(props: Props): JSX.Element | null {
   const { amount, percentage } = useGetSurplus(props)
-  const tooltipPlacement = 'top'
-  const { tooltipProps, targetProps } = usePopperOnClick<HTMLInputElement>(tooltipPlacement)
 
   if (amount === undefined || percentage === undefined) return null
 
   return (
-    <span className="wrap-datedisplay">
-      <Tooltip {...tooltipProps}>{amount}</Tooltip>
-      <Wrapper>
-        <span {...targetProps}>
+    <BaseIconTooltip
+      tooltip={amount}
+      targetContent={
+        <span>
           <IconWrapper icon={faIcon} />
           <Surplus>{percentage}</Surplus>
         </span>
-        {/* <UsdAmount>(~${formattedUsdAmount})</UsdAmount> */}
-      </Wrapper>
-    </span>
+      }
+    />
   )
 }

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 import { Order } from 'api/operator'
 
@@ -8,7 +8,7 @@ import { formatSmart, formatSmartMaxPrecision, safeTokenName } from 'utils'
 import { LOW_PRECISION_DECIMALS, PERCENTAGE_PRECISION } from 'apps/explorer/const'
 import { BaseIconTooltip } from 'components/Tooltip'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faThumbsUp as faIcon } from '@fortawesome/free-regular-svg-icons'
+import { faArrowAltCircleUp as faIcon } from '@fortawesome/free-regular-svg-icons'
 
 const Wrapper = styled.div`
   display: flex;
@@ -92,6 +92,7 @@ const IconWrapper = styled(FontAwesomeIcon)`
 
 export function OrderSurplusTooltipDisplay(props: Props): JSX.Element | null {
   const { amount, percentage } = useGetSurplus(props)
+  const theme = useTheme()
 
   if (amount === undefined || percentage === undefined) return null
 
@@ -100,7 +101,7 @@ export function OrderSurplusTooltipDisplay(props: Props): JSX.Element | null {
       tooltip={amount}
       targetContent={
         <span>
-          <IconWrapper icon={faIcon} />
+          <IconWrapper icon={faIcon} color={theme.green} />
           <Surplus>{percentage}</Surplus>
         </span>
       }

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -6,6 +6,7 @@ import { Order } from 'api/operator'
 import { formatSmart, formatSmartMaxPrecision, safeTokenName } from 'utils'
 
 import { LOW_PRECISION_DECIMALS, PERCENTAGE_PRECISION } from 'apps/explorer/const'
+import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
 
 const Wrapper = styled.div`
   & > * {
@@ -26,11 +27,12 @@ const Surplus = styled.span`
 //   opacity: 0.5;
 // `
 
-export type Props = { order: Order }
+export type Props = { order: Order; amountLikeTooltip?: boolean }
 
 export function OrderSurplusDisplay(props: Props): JSX.Element | null {
   const {
     order: { kind, buyToken, sellToken, surplusAmount, surplusPercentage },
+    amountLikeTooltip,
   } = props
 
   const surplusToken = kind === 'buy' ? sellToken : buyToken
@@ -49,6 +51,8 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
   })
   const formattedSurplusAmount = formatSmartMaxPrecision(surplusAmount, surplusToken)
   const tokenSymbol = safeTokenName(surplusToken)
+  const amountText = `${formattedSurplusAmount} ${tokenSymbol}`
+  const percentageText = `+${formattedSurplusPercentage}%`
   // const formattedUsdAmount = formatSmart({
   //   amount: usdAmount,
   //   precision: NO_ADJUSTMENT_NEEDED_PRECISION,
@@ -57,10 +61,16 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
 
   return (
     <Wrapper>
-      <Surplus>+{formattedSurplusPercentage}%</Surplus>
-      <span>
-        {formattedSurplusAmount} {tokenSymbol}
-      </span>
+      {amountLikeTooltip ? (
+        <TextWithTooltip textInTooltip={amountText}>
+          <Surplus>{percentageText}</Surplus>
+        </TextWithTooltip>
+      ) : (
+        <>
+          <Surplus>{percentageText}</Surplus>
+          <span>{amountText}</span>
+        </>
+      )}
       {/* <UsdAmount>(~${formattedUsdAmount})</UsdAmount> */}
     </Wrapper>
   )

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -30,7 +30,7 @@ const Surplus = styled.span`
 //   opacity: 0.5;
 // `
 
-export type Props = { order: Order }
+export type Props = { order: Order } & React.HTMLAttributes<HTMLDivElement>
 type SurplusText = { amount: string; percentage: string }
 
 function useGetSurplus(props: Props): SurplusText {
@@ -72,7 +72,7 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
   if (amount === undefined || percentage === undefined) return null
 
   return (
-    <Wrapper>
+    <Wrapper className={props.className}>
       <Surplus>{percentage}</Surplus>
       <span>{amount}</span>
       {/* <UsdAmount>(~${formattedUsdAmount})</UsdAmount> */}

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -37,7 +37,7 @@ const Surplus = styled.span`
 // `
 
 export type Props = { order: Order; amountSmartFormatting?: boolean } & React.HTMLAttributes<HTMLDivElement>
-type SurplusText = { amount: string; percentage: string; amountSmartFormatting: string }
+type SurplusText = { amount: string; percentage: string; formattedSmartAmount: string }
 
 function useGetSurplus(order: Order): SurplusText | null {
   const { kind, buyToken, sellToken, surplusAmount, surplusPercentage } = order
@@ -72,7 +72,7 @@ function useGetSurplus(order: Order): SurplusText | null {
 
   return {
     amount: `${formattedSurplusAmountMaxPrecision} ${tokenSymbol}`,
-    amountSmartFormatting: `${formattedSurplusAmount} ${tokenSymbol}`,
+    formattedSmartAmount: `${formattedSurplusAmount} ${tokenSymbol}`,
     percentage: `+${formattedSurplusPercentage}%`,
   }
 }
@@ -85,7 +85,7 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
   return (
     <Wrapper className={props.className}>
       <Surplus>{surplus.percentage}</Surplus>
-      <span>{props.amountSmartFormatting ? surplus.amountSmartFormatting : surplus.amount}</span>
+      <span>{props.amountSmartFormatting ? surplus.formattedSmartAmount : surplus.amount}</span>
       {/* <UsdAmount>(~${formattedUsdAmount})</UsdAmount> */}
     </Wrapper>
   )

--- a/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
@@ -7,7 +7,7 @@ import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
 import { OrderSurplusTooltipDisplay, OrderSurplusDisplay } from '../OrderSurplusDisplay'
 
 export const OrderSurplusDisplayStyled = styled(OrderSurplusDisplay)`
-  ${media.xSmallDown} {
+  ${media.mobile} {
     flex-direction: column;
   }
 `
@@ -21,5 +21,5 @@ export function OrderSurplusDisplayStyledByRow({ order }: { order: Order }): JSX
     return <OrderSurplusTooltipDisplay order={order} />
   }
 
-  return <OrderSurplusDisplayStyled order={order} />
+  return <OrderSurplusDisplayStyled order={order} amountSmartFormatting />
 }

--- a/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { media } from 'theme/styles/media'
+import { Order } from 'api/operator'
+import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
+import { OrderSurplusTooltipDisplay, OrderSurplusDisplay } from '../OrderSurplusDisplay'
+
+export const OrderSurplusDisplayStyled = styled(OrderSurplusDisplay)`
+  ${media.xSmallDown} {
+    flex-direction: column;
+  }
+`
+/**
+ * Displays surplus amount inside tooltip when display mode has little space to display
+ */
+export function OrderSurplusDisplayStyledByRow({ order }: { order: Order }): JSX.Element {
+  const isDesktop = useMediaBreakpoint(['xl', 'lg'])
+
+  if (isDesktop) {
+    return <OrderSurplusTooltipDisplay order={order} />
+  }
+
+  return <OrderSurplusDisplayStyled order={order} />
+}

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -22,11 +22,12 @@ import TradeOrderType from 'components/common/TradeOrderType'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
 import Spinner from 'components/common/Spinner'
+import { OrderSurplusDisplayStyledByRow } from './OrderSurplusTooltipStyledByRow'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) repeat(2, minmax(18rem, 2fr)) 1fr;
+    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(18rem, 2fr) 1fr;
   }
   tr > td {
     span.span-inside-tooltip {
@@ -211,6 +212,12 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
         <HeaderValue>{renderSpinnerWhenNoValue(limitPriceSettled) || limitPriceSettled}</HeaderValue>
       </td>
       <td>
+        <HeaderTitle>Surplus</HeaderTitle>
+        <HeaderValue>
+          <OrderSurplusDisplayStyledByRow order={order} />
+        </HeaderValue>
+      </td>
+      <td>
         <HeaderTitle>Created</HeaderTitle>
         <HeaderValue>
           <DateDisplay date={creationDate} showIcon={true} />
@@ -267,6 +274,7 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
           <th>
             Limit price <Icon icon={faExchangeAlt} onClick={invertLimitPrice} />
           </th>
+          <th>Surplus</th>
           <th>Created</th>
           <th>Status</th>
         </tr>

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -27,7 +27,7 @@ import { OrderSurplusDisplayStyledByRow } from './OrderSurplusTooltipStyledByRow
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(18rem, 2fr) 1fr;
+    grid-template-columns: 12rem 5.5rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(21.6rem, 2fr) 1.18fr;
   }
   tr > td {
     span.span-inside-tooltip {

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -23,12 +23,12 @@ import { TokenDisplay } from 'components/common/TokenDisplay'
 import { useNetworkId } from 'state/network'
 import { safeTokenName } from '@gnosis.pm/dex-js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
+import { OrderSurplusTooltipDisplay } from 'components/orders/OrderSurplusDisplay'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) 12rem repeat(2, minmax(18rem, 2fr)) 1fr;
+    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 7rem minmax(18rem, 2fr) 1fr;
   }
   tr > td {
     span.span-inside-tooltip {
@@ -218,7 +218,7 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
       <td>
         <HeaderTitle>Surplus</HeaderTitle>
         <HeaderValue>
-          {!surplusAmount.isZero() ? <OrderSurplusDisplay amountLikeTooltip order={order} /> : '-'}
+          {!surplusAmount.isZero() ? <OrderSurplusTooltipDisplay amountLikeTooltip order={order} /> : '-'}
         </HeaderValue>
       </td>
       <td>

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import styled from 'styled-components'
 import { faExchangeAlt, faSpinner } from '@fortawesome/free-solid-svg-icons'
 
 import { Order } from 'api/operator'
@@ -9,107 +8,19 @@ import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import { getOrderLimitPrice, formatCalculatedPriceToDisplay, formattedAmount, FormatAmountPrecision } from 'utils'
 import { getShortOrderId } from 'utils/operator'
 import { HelpTooltip } from 'components/Tooltip'
-import StyledUserDetailsTable, {
-  StyledUserDetailsTableProps,
-  EmptyItemWrapper,
-} from '../../common/StyledUserDetailsTable'
+import { StyledUserDetailsTableProps, EmptyItemWrapper } from '../../common/StyledUserDetailsTable'
 import Icon from 'components/Icon'
 import TradeOrderType from 'components/common/TradeOrderType'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import { StatusLabel } from 'components/orders/StatusLabel'
-import { media } from 'theme/styles/media'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
 import { TokenDisplay } from 'components/common/TokenDisplay'
 import { useNetworkId } from 'state/network'
 import { safeTokenName } from '@gnosis.pm/dex-js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { OrderSurplusTooltipDisplay, OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
+import { OrderSurplusTooltipDisplay } from 'components/orders/OrderSurplusDisplay'
 import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
-
-const Wrapper = styled(StyledUserDetailsTable)`
-  > thead > tr,
-  > tbody > tr {
-    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(18rem, 2fr) 1fr;
-  }
-  tr > td {
-    span.span-inside-tooltip {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
-      img {
-        padding: 0;
-      }
-    }
-  }
-  ${media.desktopMediumDown} {
-    > thead > tr {
-      display: none;
-    }
-    > tbody > tr {
-      grid-template-columns: none;
-      border: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
-      box-shadow: 0px 4px 12px ${({ theme }): string => theme.boxShadow};
-      border-radius: 6px;
-      margin-top: 16px;
-      padding: 12px;
-      &:hover {
-        background: none;
-        backdrop-filter: none;
-      }
-    }
-    tr > td {
-      display: flex;
-      flex: 1;
-      width: 100%;
-      justify-content: space-between;
-      margin: 0;
-      margin-bottom: 18px;
-      min-height: 32px;
-      span.span-inside-tooltip {
-        align-items: flex-end;
-        flex-direction: column;
-        img {
-          margin-left: 0;
-        }
-      }
-    }
-    .header-value {
-      flex-wrap: wrap;
-      text-align: end;
-    }
-    .span-copybtn-wrap {
-      display: flex;
-      flex-wrap: nowrap;
-      span {
-        display: flex;
-        align-items: center;
-      }
-      .copy-text {
-        margin-left: 5px;
-      }
-    }
-  }
-  overflow: auto;
-`
-
-const HeaderTitle = styled.span`
-  display: none;
-  ${media.desktopMediumDown} {
-    font-weight: 600;
-    align-items: center;
-    display: flex;
-    margin-right: 3rem;
-    svg {
-      margin-left: 5px;
-    }
-  }
-`
-const HeaderValue = styled.span`
-  ${media.desktopMediumDown} {
-    flex-wrap: wrap;
-    text-align: end;
-  }
-`
+import { HeaderTitle, HeaderValue, WrapperUserDetailsTable, OrderSurplusDisplayStyled } from './styled'
 
 function getLimitPrice(order: Order, isPriceInverted: boolean): string {
   if (!order.buyToken || !order.sellToken) return '-'
@@ -219,7 +130,7 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
       <td>
         <HeaderTitle>Surplus</HeaderTitle>
         <HeaderValue>
-          {isDesktop ? <OrderSurplusTooltipDisplay order={order} /> : <OrderSurplusDisplay order={order} />}
+          {isDesktop ? <OrderSurplusTooltipDisplay order={order} /> : <OrderSurplusDisplayStyled order={order} />}
         </HeaderValue>
       </td>
       <td>
@@ -278,7 +189,7 @@ const TransactionTable: React.FC<Props> = (props) => {
   }
 
   return (
-    <Wrapper
+    <WrapperUserDetailsTable
       showBorderTable={showBorderTable}
       header={
         <tr>

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -28,7 +28,7 @@ import { OrderSurplusTooltipDisplay } from 'components/orders/OrderSurplusDispla
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 7rem minmax(18rem, 2fr) 1fr;
+    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(18rem, 2fr) 1fr;
   }
   tr > td {
     span.span-inside-tooltip {

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -23,11 +23,12 @@ import { TokenDisplay } from 'components/common/TokenDisplay'
 import { useNetworkId } from 'state/network'
 import { safeTokenName } from '@gnosis.pm/dex-js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) repeat(2, minmax(18rem, 2fr)) 1fr;
+    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) 12rem repeat(2, minmax(18rem, 2fr)) 1fr;
   }
   tr > td {
     span.span-inside-tooltip {
@@ -149,6 +150,7 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
     txHash,
     shortId,
     uid,
+    surplusAmount,
   } = order
   const network = useNetworkId()
   const buyTokenSymbol = buyToken ? safeTokenName(buyToken) : ''
@@ -212,6 +214,12 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
           <Icon icon={faExchangeAlt} onClick={invertLimitPrice} />
         </HeaderTitle>
         <HeaderValue>{renderSpinnerWhenNoValue(limitPriceSettled) || limitPriceSettled}</HeaderValue>
+      </td>
+      <td>
+        <HeaderTitle>Surplus</HeaderTitle>
+        <HeaderValue>
+          {!surplusAmount.isZero() ? <OrderSurplusDisplay amountLikeTooltip order={order} /> : '-'}
+        </HeaderValue>
       </td>
       <td>
         <HeaderTitle>Created</HeaderTitle>
@@ -282,6 +290,7 @@ const TransactionTable: React.FC<Props> = (props) => {
           <th>
             Limit price <Icon icon={faExchangeAlt} onClick={invertLimitPrice} />
           </th>
+          <th>Surplus</th>
           <th>Created</th>
           <th>Status</th>
         </tr>

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -23,7 +23,8 @@ import { TokenDisplay } from 'components/common/TokenDisplay'
 import { useNetworkId } from 'state/network'
 import { safeTokenName } from '@gnosis.pm/dex-js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { OrderSurplusTooltipDisplay } from 'components/orders/OrderSurplusDisplay'
+import { OrderSurplusTooltipDisplay, OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
+import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
@@ -150,13 +151,13 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
     txHash,
     shortId,
     uid,
-    surplusAmount,
   } = order
   const network = useNetworkId()
   const buyTokenSymbol = buyToken ? safeTokenName(buyToken) : ''
   const sellTokenSymbol = sellToken ? safeTokenName(sellToken) : ''
   const sellFormattedAmount = formattedAmount(sellToken, sellAmount)
   const buyFormattedAmount = formattedAmount(buyToken, buyAmount)
+  const isDesktop = useMediaBreakpoint(['xl', 'lg'])
   const renderSpinnerWhenNoValue = (textValue: string): JSX.Element | void => {
     if (textValue === '-') return <FontAwesomeIcon icon={faSpinner} spin size="1x" />
   }
@@ -218,7 +219,7 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
       <td>
         <HeaderTitle>Surplus</HeaderTitle>
         <HeaderValue>
-          {!surplusAmount.isZero() ? <OrderSurplusTooltipDisplay amountLikeTooltip order={order} /> : '-'}
+          {isDesktop ? <OrderSurplusTooltipDisplay order={order} /> : <OrderSurplusDisplay order={order} />}
         </HeaderValue>
       </td>
       <td>

--- a/src/components/transaction/TransactionTable/index.tsx
+++ b/src/components/transaction/TransactionTable/index.tsx
@@ -18,9 +18,8 @@ import { TokenDisplay } from 'components/common/TokenDisplay'
 import { useNetworkId } from 'state/network'
 import { safeTokenName } from '@gnosis.pm/dex-js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { OrderSurplusTooltipDisplay } from 'components/orders/OrderSurplusDisplay'
-import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
-import { HeaderTitle, HeaderValue, WrapperUserDetailsTable, OrderSurplusDisplayStyled } from './styled'
+import { HeaderTitle, HeaderValue, WrapperUserDetailsTable } from './styled'
+import { OrderSurplusDisplayStyledByRow } from 'components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow'
 
 function getLimitPrice(order: Order, isPriceInverted: boolean): string {
   if (!order.buyToken || !order.sellToken) return '-'
@@ -68,7 +67,6 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
   const sellTokenSymbol = sellToken ? safeTokenName(sellToken) : ''
   const sellFormattedAmount = formattedAmount(sellToken, sellAmount)
   const buyFormattedAmount = formattedAmount(buyToken, buyAmount)
-  const isDesktop = useMediaBreakpoint(['xl', 'lg'])
   const renderSpinnerWhenNoValue = (textValue: string): JSX.Element | void => {
     if (textValue === '-') return <FontAwesomeIcon icon={faSpinner} spin size="1x" />
   }
@@ -130,7 +128,7 @@ const RowTransaction: React.FC<RowProps> = ({ order, isPriceInverted, invertLimi
       <td>
         <HeaderTitle>Surplus</HeaderTitle>
         <HeaderValue>
-          {isDesktop ? <OrderSurplusTooltipDisplay order={order} /> : <OrderSurplusDisplayStyled order={order} />}
+          <OrderSurplusDisplayStyledByRow order={order} />
         </HeaderValue>
       </td>
       <td>

--- a/src/components/transaction/TransactionTable/styled.ts
+++ b/src/components/transaction/TransactionTable/styled.ts
@@ -1,4 +1,3 @@
-import { OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
 import styled from 'styled-components'
 
 import { media } from 'theme/styles/media'
@@ -86,11 +85,5 @@ export const HeaderValue = styled.span`
   ${media.desktopMediumDown} {
     flex-wrap: wrap;
     text-align: end;
-  }
-`
-
-export const OrderSurplusDisplayStyled = styled(OrderSurplusDisplay)`
-  ${media.xSmallDown} {
-    flex-direction: column;
   }
 `

--- a/src/components/transaction/TransactionTable/styled.ts
+++ b/src/components/transaction/TransactionTable/styled.ts
@@ -1,0 +1,96 @@
+import { OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
+import styled from 'styled-components'
+
+import { media } from 'theme/styles/media'
+import StyledUserDetailsTable from '../../common/StyledUserDetailsTable'
+
+export const WrapperUserDetailsTable = styled(StyledUserDetailsTable)`
+  > thead > tr,
+  > tbody > tr {
+    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(18rem, 2fr) 1fr;
+  }
+  tr > td {
+    span.span-inside-tooltip {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      img {
+        padding: 0;
+      }
+    }
+  }
+  ${media.desktopMediumDown} {
+    > thead > tr {
+      display: none;
+    }
+    > tbody > tr {
+      grid-template-columns: none;
+      border: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
+      box-shadow: 0px 4px 12px ${({ theme }): string => theme.boxShadow};
+      border-radius: 6px;
+      margin-top: 16px;
+      padding: 12px;
+      &:hover {
+        background: none;
+        backdrop-filter: none;
+      }
+    }
+    tr > td {
+      display: flex;
+      flex: 1;
+      width: 100%;
+      justify-content: space-between;
+      margin: 0;
+      margin-bottom: 18px;
+      min-height: 32px;
+      span.span-inside-tooltip {
+        align-items: flex-end;
+        flex-direction: column;
+        img {
+          margin-left: 0;
+        }
+      }
+    }
+    .header-value {
+      flex-wrap: wrap;
+      text-align: end;
+    }
+    .span-copybtn-wrap {
+      display: flex;
+      flex-wrap: nowrap;
+      span {
+        display: flex;
+        align-items: center;
+      }
+      .copy-text {
+        margin-left: 5px;
+      }
+    }
+  }
+  overflow: auto;
+`
+
+export const HeaderTitle = styled.span`
+  display: none;
+  ${media.desktopMediumDown} {
+    font-weight: 600;
+    align-items: center;
+    display: flex;
+    margin-right: 3rem;
+    svg {
+      margin-left: 5px;
+    }
+  }
+`
+export const HeaderValue = styled.span`
+  ${media.desktopMediumDown} {
+    flex-wrap: wrap;
+    text-align: end;
+  }
+`
+
+export const OrderSurplusDisplayStyled = styled(OrderSurplusDisplay)`
+  ${media.xSmallDown} {
+    flex-direction: column;
+  }
+`

--- a/src/components/transaction/TransactionTable/styled.ts
+++ b/src/components/transaction/TransactionTable/styled.ts
@@ -6,7 +6,7 @@ import StyledUserDetailsTable from '../../common/StyledUserDetailsTable'
 export const WrapperUserDetailsTable = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 12rem 7rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(18rem, 2fr) 1fr;
+    grid-template-columns: 12rem 5.5rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(21.6rem, 2fr) 1fr;
   }
   tr > td {
     span.span-inside-tooltip {

--- a/src/hooks/useGetMatchingScreenSize.tsx
+++ b/src/hooks/useGetMatchingScreenSize.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+import { getMatchingScreenSize, subscribeToScreenSizeChange, Breakpoints } from 'utils/mediaQueries'
+
+export function useGetMatchingScreenSize(): Breakpoints {
+  const [resolution, setResolution] = useState<Breakpoints>(getMatchingScreenSize())
+
+  useEffect(() => {
+    const mediaQuery = subscribeToScreenSizeChange(() => setResolution(getMatchingScreenSize()))
+    return (): void => mediaQuery()
+  }, [])
+
+  return resolution
+}

--- a/src/hooks/useMediaBreakPoint.tsx
+++ b/src/hooks/useMediaBreakPoint.tsx
@@ -1,0 +1,8 @@
+import { useGetMatchingScreenSize } from 'hooks/useGetMatchingScreenSize'
+import { Breakpoints } from 'utils/mediaQueries'
+
+export function useMediaBreakpoint(breakpoints: Breakpoints[]): boolean {
+  const resolution = useGetMatchingScreenSize()
+
+  return breakpoints.includes(resolution)
+}

--- a/src/utils/mediaQueries.ts
+++ b/src/utils/mediaQueries.ts
@@ -1,6 +1,8 @@
 import { Command } from 'types'
 
-export const MEDIA_QUERY_MATCHES = [
+export type Breakpoints = 'xl' | 'lg' | 'md' | 'sm' | 'xs'
+
+export const MEDIA_QUERY_MATCHES: Array<{ name: Breakpoints; query: string }> = [
   // must be in descending order for .find to match from largest to smallest
   // as sm will also match for xl and lg, for example
   {
@@ -22,9 +24,9 @@ export const MEDIA_QUERY_MATCHES = [
   // anything smaller -- xs
 ]
 
-const DEFAULT_QUERY_NAME = 'xs'
+const DEFAULT_QUERY_NAME: Breakpoints = 'xs'
 
-export const getMatchingScreenSize = (): string =>
+export const getMatchingScreenSize = (): Breakpoints =>
   MEDIA_QUERY_MATCHES.find(({ query }) => window.matchMedia(query).matches)?.name || DEFAULT_QUERY_NAME
 
 export const MEDIA_QUERIES = MEDIA_QUERY_MATCHES.map(({ query }) => query)
@@ -33,7 +35,7 @@ export const MEDIA_QUERY_NAMES = MEDIA_QUERY_MATCHES.map(({ name }) => name).con
 export const subscribeToScreenSizeChange = (callback: (event: MediaQueryListEvent) => void): Command => {
   const mediaQueryLists = MEDIA_QUERIES.map((query) => window.matchMedia(query))
 
-  mediaQueryLists.forEach((mql) => mql.addListener(callback))
+  mediaQueryLists.forEach((mql) => mql.addEventListener('change', callback))
 
-  return (): void => mediaQueryLists.forEach((mql) => mql.removeListener(callback))
+  return (): void => mediaQueryLists.forEach((mql) => mql.removeEventListener('change', callback))
 }


### PR DESCRIPTION
# Summary

Closes #74 
Adding surplus column on tx table and userOrders table
![Selection_540](https://user-images.githubusercontent.com/4270166/170613238-d4187703-49df-4210-8a31-8ae6b218858e.png)
![Selection_541](https://user-images.githubusercontent.com/4270166/170620718-5f31413b-6a3a-4d92-a147-be001ff7f44a.png)


## To Test
-Go to [transaction table view](https://pr99--explorer.review.gnosisdev.com//rinkeby/tx/0xaa5daa29e997cbf9b6307c707f13c76c3e2cb53ee41b8e85dc3e36e808cbbaf0?tab=orders) 