### PR TITLE
Fetch orders and order detail from barn and prod apis

### DIFF
--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -30,6 +30,8 @@ function getOperatorUrl(): Partial<Record<Network, string>> {
   }
 }
 
+const COW_SDK_ENV = isProd || isStaging ? COW_SDK : COW_SDK_DEV
+
 const API_BASE_URL = getOperatorUrl()
 
 const DEFAULT_HEADERS: Headers = new Headers({
@@ -118,7 +120,7 @@ export async function getOrders(params: GetOrdersParams): Promise<RawOrder[]> {
  */
 export async function getAccountOrders(params: GetAccountOrdersParams): Promise<RawOrder[]> {
   const { networkId, owner, offset, limit } = params
-  const cowInstance = COW_SDK[networkId]
+  const cowInstance = COW_SDK_ENV[networkId]
 
   if (!cowInstance) return []
 
@@ -154,7 +156,7 @@ export async function getTxOrders(params: GetTxOrdersParams): Promise<RawOrder[]
  */
 export async function getTrades(params: GetTradesParams): Promise<RawTrade[]> {
   const { networkId, owner = '', orderId = '' } = params
-  const cowInstance = COW_SDK[networkId]
+  const cowInstance = COW_SDK_ENV[networkId]
 
   if (orderId) return getOrderTrades(params)
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import BN from 'bn.js'
-import { CowSdk } from '@cowprotocol/cow-sdk'
+import { CowSdk, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { TokenErc20, UNLIMITED_ORDER_AMOUNT, BATCH_TIME } from '@gnosis.pm/dex-js'
 export {
   UNLIMITED_ORDER_AMOUNT,
@@ -19,7 +19,6 @@ export {
 } from '@gnosis.pm/dex-js'
 import { Network } from 'types'
 import { DisabledTokensMaps, TokenOverride, AddressToOverrideMap } from 'types/config'
-import { isProd, isStaging } from 'utils/env'
 
 export const BATCH_TIME_IN_MS = BATCH_TIME * 1000
 export const DEFAULT_TIMEOUT = 5000
@@ -229,17 +228,31 @@ export const DISABLED_TOKEN_MAPS = Object.keys(disabledTokens).reduce<DisabledTo
 )
 
 export const COW_SDK = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN].reduce<
-  Record<number, CowSdk<any> | null> //These type are temporary until SupportedChainId is exported
+  Record<number, CowSdk<SupportedChainId> | null>
 >((acc, networkId) => {
   try {
-    acc[networkId] = new CowSdk(networkId as any, {
-      isDevEnvironment: !(isProd || isStaging),
-    })
+    acc[networkId] = new CowSdk(networkId)
   } catch (error) {
     console.error('Instantiating CowSdk failed', error)
   }
 
   console.info(`CowSdk initialized on chain ${networkId}`)
+
+  return acc
+}, {})
+
+export const COW_SDK_DEV = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN].reduce<
+  Record<number, CowSdk<SupportedChainId> | null>
+>((acc, networkId) => {
+  try {
+    acc[networkId] = new CowSdk(networkId, {
+      isDevEnvironment: true,
+    })
+  } catch (error) {
+    console.error('Instantiating CowSdk in development mode failed', error)
+  }
+
+  console.info(`CowSdk in development mode initialized on chain ${networkId}`)
 
   return acc
 }, {})

--- a/src/hooks/useGetOrders.tsx
+++ b/src/hooks/useGetOrders.tsx
@@ -14,7 +14,7 @@ import {
   GetOrderResult,
   MultipleOrders,
   GetOrderApi,
-  tryGetOrderOnAllNetworks,
+  tryGetOrderOnAllNetworksAndEnvironments,
 } from 'services/helpers/tryGetOrderOnAllNetworks'
 
 function isObjectEmpty(object: Record<string, unknown>): boolean {
@@ -62,14 +62,17 @@ interface UseOrdersWithTokenInfo {
   setErc20Addresses: (value: string[]) => void
 }
 
-export function getTxOrderOnEveryNetwork(networkId: Network, txHash: string): Promise<GetOrderResult<MultipleOrders>> {
+export function getTxOrderOnEveryNetworkAndEnvironment(
+  networkId: Network,
+  txHash: string,
+): Promise<GetOrderResult<MultipleOrders>> {
   const defaultParams: GetTxOrdersParams = { networkId, txHash }
   const getOrderApi: GetOrderApi<GetTxOrdersParams, MultipleOrders> = {
     api: (_defaultParams) => getTxOrders(_defaultParams).then((orders) => (orders.length ? orders : null)),
     defaultParams,
   }
 
-  return tryGetOrderOnAllNetworks(networkId, getOrderApi)
+  return tryGetOrderOnAllNetworksAndEnvironments(networkId, getOrderApi)
 }
 
 function useOrdersWithTokenInfo(networkId: Network | undefined): UseOrdersWithTokenInfo {
@@ -116,7 +119,7 @@ export function useGetTxOrders(txHash: string): GetTxOrdersResult {
 
       try {
         const { order: _orders, errorOrderPresentInNetworkId: errorTxPresentInNetworkIdRaw } =
-          await getTxOrderOnEveryNetwork(network, _txHash)
+          await getTxOrderOnEveryNetworkAndEnvironment(network, _txHash)
         const ordersFetched = _orders || []
         const newErc20Addresses = filterDuplicateErc20Addresses(ordersFetched)
 

--- a/src/hooks/useOperatorOrder.ts
+++ b/src/hooks/useOperatorOrder.ts
@@ -12,7 +12,7 @@ import {
   GetOrderApi,
   GetOrderResult,
   SingleOrder,
-  tryGetOrderOnAllNetworks,
+  tryGetOrderOnAllNetworksAndEnvironments,
 } from 'services/helpers/tryGetOrderOnAllNetworks'
 
 type UseOrderResult = {
@@ -30,7 +30,7 @@ function _getOrder(networkId: Network, orderId: string): Promise<GetOrderResult<
     defaultParams,
   }
 
-  return tryGetOrderOnAllNetworks<SingleOrder>(networkId, getOrderApi)
+  return tryGetOrderOnAllNetworksAndEnvironments<SingleOrder>(networkId, getOrderApi)
 }
 
 export function useOrderByNetwork(orderId: string, networkId: Network | null, updateInterval = 0): UseOrderResult {

--- a/src/services/helpers/tryGetOrderOnAllNetworks.ts
+++ b/src/services/helpers/tryGetOrderOnAllNetworks.ts
@@ -26,7 +26,7 @@ export type GetOrderApi<T, R> = {
 
 type TypeOrderApiParams = GetOrderParams | GetTxOrdersParams
 
-export async function tryGetOrderOnAllNetworks<TypeOrderResult>(
+export async function tryGetOrderOnAllNetworksAndEnvironments<TypeOrderResult>(
   networkId: Network,
   getOrderApi: GetOrderApi<TypeOrderApiParams, TypeOrderResult>,
   networkIdSearchListRemaining: Network[] = NETWORK_ID_SEARCH_LIST,
@@ -57,6 +57,6 @@ export async function tryGetOrderOnAllNetworks<TypeOrderResult>(
     }
   } else {
     // Keep looking in other networks
-    return tryGetOrderOnAllNetworks(nextNetworkId, getOrderApi, remainingNetworkIds)
+    return tryGetOrderOnAllNetworksAndEnvironments(nextNetworkId, getOrderApi, remainingNetworkIds)
   }
 }

--- a/test/services/tryGetOrderOnAllNetworks.test.ts
+++ b/test/services/tryGetOrderOnAllNetworks.test.ts
@@ -1,5 +1,5 @@
 import { GetTxOrdersParams } from 'api/operator/types'
-import { GetOrderApi, MultipleOrders, tryGetOrderOnAllNetworks } from 'services/helpers/tryGetOrderOnAllNetworks'
+import { GetOrderApi, MultipleOrders, tryGetOrderOnAllNetworksAndEnvironments } from 'services/helpers/tryGetOrderOnAllNetworks'
 import { RAW_ORDER } from '../data'
 import { Network } from 'types'
 
@@ -16,7 +16,7 @@ describe('tryGetOrderOnAllNetworks', () => {
       api: mockedApi,
       defaultParams,
     }
-    const result = await tryGetOrderOnAllNetworks(network, getOrderApi, networkIdSearchListRemaining)
+    const result = await tryGetOrderOnAllNetworksAndEnvironments(network, getOrderApi, networkIdSearchListRemaining)
 
     expect(mockedApi).toHaveBeenLastCalledWith({ networkId: Network.MAINNET, txHash })
     expect(result).toEqual({ order: null })
@@ -32,7 +32,7 @@ describe('tryGetOrderOnAllNetworks', () => {
       api: mockedApi,
       defaultParams,
     }
-    const result = await tryGetOrderOnAllNetworks(network, getOrderApi, networkIdSearchListRemaining)
+    const result = await tryGetOrderOnAllNetworksAndEnvironments(network, getOrderApi, networkIdSearchListRemaining)
 
     expect(mockedApi).not.toHaveBeenCalledWith({ networkId: Network.MAINNET, txHash })
     expect(result).toEqual({ order: ordersResult })


### PR DESCRIPTION
# Summary

Closes #92

Two things were implemented:
1. When looking for a batch it searches on both the prod and barn APIs and the responses are merged
2. When looking for an order id it first fetch the prod API and then barn

# To Test

1. Click on the Batch ID link <img width="213" alt="image" src="https://user-images.githubusercontent.com/3328006/171162890-ca34001f-8fba-47b8-9166-17a3cdbde97a.png">
2. The page should load fine without throwing a `No results found`
