### PR TITLE
Increase column, show dash and use tooltip mobile

### DIFF
--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -102,7 +102,7 @@ const IconWrapper = styled(FontAwesomeIcon)`
 `
 
 const HiddenSection = styled.span<{ showHiddenSection: boolean }>`
-  display: ${({ showHiddenSection }): string => (showHiddenSection ? 'block' : 'none')};
+  display: ${({ showHiddenSection }): string => (showHiddenSection ? 'flex' : 'none')};
 `
 
 export function OrderSurplusTooltipDisplay({
@@ -114,7 +114,7 @@ export function OrderSurplusTooltipDisplay({
   const surplus = useGetSurplus(order)
   const theme = useTheme()
 
-  if (!surplus) return <HiddenSection showHiddenSection={showHiddenSection}>{defaultWhenNoSurplus}</HiddenSection>
+  if (!surplus) return <HiddenSection showHiddenSection>{defaultWhenNoSurplus}</HiddenSection>
 
   return (
     <BaseIconTooltipOnHover

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -101,11 +101,20 @@ const IconWrapper = styled(FontAwesomeIcon)`
   }
 `
 
-export function OrderSurplusTooltipDisplay({ order }: Props): JSX.Element | null {
+const HiddenSection = styled.span<{ showHiddenSection: boolean }>`
+  display: ${({ showHiddenSection }): string => (showHiddenSection ? 'block' : 'none')};
+`
+
+export function OrderSurplusTooltipDisplay({
+  order,
+  amountSmartFormatting,
+  showHiddenSection = false,
+  defaultWhenNoSurplus,
+}: Props & { showHiddenSection?: boolean; defaultWhenNoSurplus?: string }): JSX.Element {
   const surplus = useGetSurplus(order)
   const theme = useTheme()
 
-  if (!surplus) return null
+  if (!surplus) return <HiddenSection showHiddenSection={showHiddenSection}>{defaultWhenNoSurplus}</HiddenSection>
 
   return (
     <BaseIconTooltipOnHover
@@ -114,6 +123,9 @@ export function OrderSurplusTooltipDisplay({ order }: Props): JSX.Element | null
         <span>
           <IconWrapper icon={faIcon} color={theme.green} />
           <Surplus>{surplus.percentage}</Surplus>
+          <HiddenSection showHiddenSection={showHiddenSection}>
+            {amountSmartFormatting ? surplus.formattedSmartAmount : surplus.amount}
+          </HiddenSection>
         </span>
       }
     />

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -106,7 +106,7 @@ const HiddenSection = styled.span<{ showHiddenSection: boolean; strechHiddenSect
   ${({ strechHiddenSection }): FlattenSimpleInterpolation | false =>
     strechHiddenSection &&
     css`
-      width: 4rem;
+      width: 3.4rem;
       display: 'inline-block';
       justify-content: end;
     `}

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -101,9 +101,9 @@ const IconWrapper = styled(FontAwesomeIcon)`
   }
 `
 
-const HiddenSection = styled.span<{ showHiddenSection: boolean; strechHiddenSection: boolean }>`
+const HiddenSection = styled.span<{ showHiddenSection: boolean; strechHiddenSection?: boolean }>`
   display: ${({ showHiddenSection }): string => (showHiddenSection ? 'flex' : 'none')};
-  ${({ strechHiddenSection }): FlattenSimpleInterpolation | false =>
+  ${({ strechHiddenSection }): FlattenSimpleInterpolation | false | undefined =>
     strechHiddenSection &&
     css`
       width: 3.4rem;
@@ -117,18 +117,18 @@ export function OrderSurplusTooltipDisplay({
   amountSmartFormatting,
   showHiddenSection = false,
   defaultWhenNoSurplus,
-  strechHiddenSection = false,
+  strechWhenNoSurplus = false,
 }: Props & {
   showHiddenSection?: boolean
   defaultWhenNoSurplus?: string
-  strechHiddenSection?: boolean
+  strechWhenNoSurplus?: boolean
 }): JSX.Element {
   const surplus = useGetSurplus(order)
   const theme = useTheme()
 
   if (!surplus)
     return (
-      <HiddenSection showHiddenSection strechHiddenSection={strechHiddenSection}>
+      <HiddenSection showHiddenSection strechHiddenSection={strechWhenNoSurplus}>
         {defaultWhenNoSurplus}
       </HiddenSection>
     )
@@ -140,7 +140,7 @@ export function OrderSurplusTooltipDisplay({
         <span>
           <IconWrapper icon={faIcon} color={theme.green} />
           <Surplus>{surplus.percentage}</Surplus>
-          <HiddenSection showHiddenSection={showHiddenSection} strechHiddenSection>
+          <HiddenSection showHiddenSection={showHiddenSection}>
             {amountSmartFormatting ? surplus.formattedSmartAmount : surplus.amount}
           </HiddenSection>
         </span>

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled, { useTheme } from 'styled-components'
+import styled, { css, useTheme, FlattenSimpleInterpolation } from 'styled-components'
 
 import { Order } from 'api/operator'
 
@@ -101,8 +101,15 @@ const IconWrapper = styled(FontAwesomeIcon)`
   }
 `
 
-const HiddenSection = styled.span<{ showHiddenSection: boolean }>`
+const HiddenSection = styled.span<{ showHiddenSection: boolean; strechHiddenSection: boolean }>`
   display: ${({ showHiddenSection }): string => (showHiddenSection ? 'flex' : 'none')};
+  ${({ strechHiddenSection }): FlattenSimpleInterpolation | false =>
+    strechHiddenSection &&
+    css`
+      width: 4rem;
+      display: 'inline-block';
+      justify-content: end;
+    `}
 `
 
 export function OrderSurplusTooltipDisplay({
@@ -110,11 +117,21 @@ export function OrderSurplusTooltipDisplay({
   amountSmartFormatting,
   showHiddenSection = false,
   defaultWhenNoSurplus,
-}: Props & { showHiddenSection?: boolean; defaultWhenNoSurplus?: string }): JSX.Element {
+  strechHiddenSection = false,
+}: Props & {
+  showHiddenSection?: boolean
+  defaultWhenNoSurplus?: string
+  strechHiddenSection?: boolean
+}): JSX.Element {
   const surplus = useGetSurplus(order)
   const theme = useTheme()
 
-  if (!surplus) return <HiddenSection showHiddenSection>{defaultWhenNoSurplus}</HiddenSection>
+  if (!surplus)
+    return (
+      <HiddenSection showHiddenSection strechHiddenSection={strechHiddenSection}>
+        {defaultWhenNoSurplus}
+      </HiddenSection>
+    )
 
   return (
     <BaseIconTooltipOnHover
@@ -123,7 +140,7 @@ export function OrderSurplusTooltipDisplay({
         <span>
           <IconWrapper icon={faIcon} color={theme.green} />
           <Surplus>{surplus.percentage}</Surplus>
-          <HiddenSection showHiddenSection={showHiddenSection}>
+          <HiddenSection showHiddenSection={showHiddenSection} strechHiddenSection>
             {amountSmartFormatting ? surplus.formattedSmartAmount : surplus.amount}
           </HiddenSection>
         </span>

--- a/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
@@ -4,20 +4,26 @@ import { Order } from 'api/operator'
 import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
 import { OrderSurplusTooltipDisplay } from '../OrderSurplusDisplay'
 
+type Props = React.HTMLAttributes<HTMLSpanElement> & {
+  order: Order
+}
+
 /**
  * Displays surplus amount inside tooltip when display mode has little space to display
  */
-export function OrderSurplusDisplayStyledByRow({ order }: { order: Order }): JSX.Element {
+export function OrderSurplusDisplayStyledByRow({ order }: Props): JSX.Element {
   const isDesktop = useMediaBreakpoint(['xl', 'lg'])
   const showAmountBesideSurplus = !isDesktop
   const defaultWhenNoSurplus = '-'
 
+  // console.log('ccass', className)
   return (
     <OrderSurplusTooltipDisplay
       order={order}
       amountSmartFormatting
       showHiddenSection={showAmountBesideSurplus}
       defaultWhenNoSurplus={defaultWhenNoSurplus}
+      strechHiddenSection
     />
   )
 }

--- a/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
@@ -1,25 +1,23 @@
 import React from 'react'
-import styled from 'styled-components'
 
-import { media } from 'theme/styles/media'
 import { Order } from 'api/operator'
 import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
-import { OrderSurplusTooltipDisplay, OrderSurplusDisplay } from '../OrderSurplusDisplay'
+import { OrderSurplusTooltipDisplay } from '../OrderSurplusDisplay'
 
-export const OrderSurplusDisplayStyled = styled(OrderSurplusDisplay)`
-  ${media.mobile} {
-    flex-direction: column;
-  }
-`
 /**
  * Displays surplus amount inside tooltip when display mode has little space to display
  */
 export function OrderSurplusDisplayStyledByRow({ order }: { order: Order }): JSX.Element {
   const isDesktop = useMediaBreakpoint(['xl', 'lg'])
+  const showAmountBesideSurplus = !isDesktop
+  const defaultWhenNoSurplus = '-'
 
-  if (isDesktop) {
-    return <OrderSurplusTooltipDisplay order={order} />
-  }
-
-  return <OrderSurplusDisplayStyled order={order} amountSmartFormatting />
+  return (
+    <OrderSurplusTooltipDisplay
+      order={order}
+      amountSmartFormatting
+      showHiddenSection={showAmountBesideSurplus}
+      defaultWhenNoSurplus={defaultWhenNoSurplus}
+    />
+  )
 }

--- a/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
@@ -23,7 +23,7 @@ export function OrderSurplusDisplayStyledByRow({ order }: Props): JSX.Element {
       amountSmartFormatting
       showHiddenSection={showAmountBesideSurplus}
       defaultWhenNoSurplus={defaultWhenNoSurplus}
-      strechHiddenSection
+      strechWhenNoSurplus
     />
   )
 }

--- a/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/OrderSurplusTooltipStyledByRow.tsx
@@ -16,7 +16,6 @@ export function OrderSurplusDisplayStyledByRow({ order }: Props): JSX.Element {
   const showAmountBesideSurplus = !isDesktop
   const defaultWhenNoSurplus = '-'
 
-  // console.log('ccass', className)
   return (
     <OrderSurplusTooltipDisplay
       order={order}

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -27,7 +27,7 @@ import { OrderSurplusDisplayStyledByRow } from './OrderSurplusTooltipStyledByRow
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 12rem 5.5rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 9rem minmax(21.6rem, 2fr) 1.18fr;
+    grid-template-columns: 11rem 5.5rem repeat(2, minmax(16rem, 1.5fr)) minmax(18rem, 2fr) 10rem minmax(21.6rem, 2fr) 1.18fr;
   }
   tr > td {
     span.span-inside-tooltip {


### PR DESCRIPTION
# Summary

Closes #109 

- [x] Expand the column to show the value in 1 line
- [x] Show 'dash' or so when there is no value in the column on mobile view
- [x] Display whole surplus amount on hover in a mobile view


# To Test

Open tx https://pr113--explorer.review.gnosisdev.com/gc/address/0x2dB8323b3766b868AAF6a967E55eEb35C233DE9d
