### PR TITLE
[Batch Viewer] Avoid multiple requests to Tenderly API

### DIFF
--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -29,6 +29,7 @@ import {
 } from 'apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChartWidget'
 import { numberFormatter } from 'apps/explorer/components/SummaryCardsWidget/utils'
 import { useNetworkId } from 'state/network'
+import { usePrevious } from 'hooks/usePrevious'
 
 const DEFAULT_CHART_HEIGHT = 214 // px
 
@@ -69,13 +70,8 @@ function _formatAmount(amount: string): string {
  *  example: <lastRecordId>-<volumePeriodSelected>
  * */
 function usePreviousLastValueData<T>(value: T): T | undefined {
-  const ref = useRef<T>()
-
-  useEffect(() => {
-    ref.current = value
-  }, [value])
-
-  return ref.current
+  const previousValue = usePrevious(value)
+  return previousValue
 }
 
 function _buildChart(

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -65,15 +65,6 @@ function _formatAmount(amount: string): string {
   return formatSmart({ amount, precision: 0, decimals: 0 })
 }
 
-/* Store an ID to check if there is new data that
- * requires the graph to be rendered.
- *  example: <lastRecordId>-<volumePeriodSelected>
- * */
-function usePreviousLastValueData<T>(value: T): T | undefined {
-  const previousValue = usePrevious(value)
-  return previousValue
-}
-
 function _buildChart(
   chartContainer: HTMLDivElement,
   width: number | undefined,
@@ -205,8 +196,8 @@ export function VolumeChart({
   const captionNameColor = getColorBySign(diffPercentageVolume || 0)
   const [crossHairData, setCrossHairData] = useState<CrossHairData | null>(null)
   const network = useNetworkId()
-  const previousPeriod = usePreviousLastValueData(period)
-  const previousNetwork = usePreviousLastValueData(network)
+  const previousPeriod = usePrevious(period)
+  const previousNetwork = usePrevious(network)
   const periodTitle = period && volumePeriodTitle.get(period)
 
   // reset the chart when the volume/network period is changed

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react'
+
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>()
+
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+
+  return ref.current
+}

--- a/src/hooks/useTxBatchTrades.tsx
+++ b/src/hooks/useTxBatchTrades.tsx
@@ -31,7 +31,7 @@ export type GetTxBatchTradesResult = {
 export function useTxBatchTrades(
   networkId: Network | undefined,
   txHash: string,
-  orders: Order[],
+  orders: Order[] | undefined,
 ): GetTxBatchTradesResult {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')

--- a/src/hooks/useTxBatchTrades.tsx
+++ b/src/hooks/useTxBatchTrades.tsx
@@ -38,7 +38,7 @@ export function useTxBatchTrades(
   const [error, setError] = useState('')
   const [txBatchTrades, setTxBatchTrades] = useState<TxBatchTrades>({ trades: [], transfers: [] })
   const [accounts, setAccounts] = useState<Accounts>()
-  const txOrders = usePrevious(JSON.stringify(orders?.map((o) => ({ owner: o.owner, kind: o.kind }))))
+  const txOrders = usePrevious(JSON.stringify(orders?.map((o) => ({ owner: o.owner, kind: o.kind })))) // We need to do a deep comparison here to avoid useEffect to be called twice (Orders array is populated partially from different places)
   const [erc20Addresses, setErc20Addresses] = useState<string[]>([])
   const { value: valueErc20s, isLoading: areErc20Loading } = useMultipleErc20({ networkId, addresses: erc20Addresses })
 


### PR DESCRIPTION
# Summary

Closes #121 

Updated Hook in order not to re-render it unnecessarily when there's no changes

# To Test

1. Go to a tx page in Batch Viewer view (`i.e: /rinkeby/tx/0xaa5daa29e997cbf9b6307c707f13c76c3e2cb53ee41b8e85dc3e36e808cbbaf0/?tab=graph`)
2.  Open network tab and search for tenderly requests
  * You will only see 2 requests (1 for getting trades and transfers and the other one for getting accounts).

