### PR TITLE
Update Get Support link on Search page

### DIFF
--- a/src/components/orders/OrderNotFound/index.tsx
+++ b/src/components/orders/OrderNotFound/index.tsx
@@ -120,7 +120,7 @@ export const OrderAddressNotFound: React.FC = (): JSX.Element => {
           <SearchContent>
             <Search searchString={wasRedirected ? '' : searchString} submitSearchImmediatly={!wasRedirected} />
             <span>or</span>
-            <Support href="https://discord.gg/cowprotocol/" target="_blank" rel="noopener noreferrer">
+            <Support href="https://discord.com/invite/cowprotocol" target="_blank" rel="noopener noreferrer">
               Get Support
               <img src={SupportIcon} />
             </Support>

--- a/src/hooks/useTxBatchTrades.tsx
+++ b/src/hooks/useTxBatchTrades.tsx
@@ -60,7 +60,9 @@ export function useTxBatchTrades(
   const [error, setError] = useState('')
   const [txBatchTrades, setTxBatchTrades] = useState<TxBatchTrades>({ trades: [], transfers: [] })
   const [accounts, setAccounts] = useState<Accounts>()
-  const txOrders = usePrevious(JSON.stringify(orders?.map((o) => ({ owner: o.owner, kind: o.kind, receiver: o.receiver })))) // We need to do a deep comparison here to avoid useEffect to be called twice (Orders array is populated partially from different places)
+  const txOrders = usePrevious(
+    JSON.stringify(orders?.map((o) => ({ owner: o.owner, kind: o.kind, receiver: o.receiver }))),
+  ) // We need to do a deep comparison here to avoid useEffect to be called twice (Orders array is populated partially from different places)
   const [erc20Addresses, setErc20Addresses] = useState<string[]>([])
   const { value: valueErc20s, isLoading: areErc20Loading } = useMultipleErc20({ networkId, addresses: erc20Addresses })
 
@@ -120,9 +122,7 @@ export function useTxBatchTrades(
     } finally {
       setIsLoading(false)
     }
-  },
-    [orders],
-  )
+  }, [])
 
   useEffect(() => {
     if (!networkId || !txOrders) {


### PR DESCRIPTION
# Summary

Closes #140 

Updated Get support link to navigate to [https://discord.com/invite/cowprotocol](https://discord.com/invite/cowprotocol)

# To Test

1. Open Explorer Home page
2. Search for an order that does not exist
3. Press on the Get support link
    * This link will redirect you to [https://discord.com/invite/cowprotocol](https://discord.com/invite/cowprotocol)

