### PR TITLE
Fix issue with executed amounts

### DIFF
--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -35,10 +35,12 @@ const Wrapper = styled.div`
 export function FilledProgress(props: Props): JSX.Element {
   const {
     order: {
+      executedFeeAmount,
       filledAmount,
       filledPercentage,
       fullyFilled,
       kind,
+      feeAmount,
       sellAmount,
       buyAmount,
       executedBuyAmount,
@@ -63,7 +65,7 @@ export function FilledProgress(props: Props): JSX.Element {
   if (kind === 'sell') {
     mainToken = sellToken
     mainAddress = sellTokenAddress
-    mainAmount = sellAmount
+    mainAmount = sellAmount.plus(feeAmount)
     swappedToken = buyToken
     swappedAddress = buyTokenAddress
     swappedAmount = executedBuyAmount
@@ -82,7 +84,7 @@ export function FilledProgress(props: Props): JSX.Element {
   const mainSymbol = mainToken ? safeTokenName(mainToken) : mainAddress
   const swappedSymbol = swappedToken ? safeTokenName(swappedToken) : swappedAddress
   // In case the token object is empty, display the raw amount (`decimals || 0` part)
-  const formattedFilledAmount = formatSmartMaxPrecision(filledAmount, mainToken)
+  const formattedFilledAmount = formatSmartMaxPrecision(filledAmount.plus(executedFeeAmount), mainToken)
   const formattedMainAmount = formatSmartMaxPrecision(mainAmount, mainToken)
   const formattedSwappedAmount = formatSmartMaxPrecision(swappedAmount, swappedToken)
 


### PR DESCRIPTION
# Summary
This PR includes the fee when displayed the FILLED amounts.

Let's explain the change with an example, selling 10 UNI for at least 223,469,689.5 DAI 

Before this change:
https://barn.explorer.cow.fi/rinkeby/orders/0x7c0c1186938ee24793f1788401f82eb37ab18546ba4b7b11e9546db515eaa070424a46612794dbb8000194937834250dc723ffa562c876ec

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/2352112/178240387-365994f2-4685-4972-8ca5-4490e2073436.png">

After this change:
https://pr161--gpui.review.gnosisdev.com/rinkeby/orders/0x7c0c1186938ee24793f1788401f82eb37ab18546ba4b7b11e9546db515eaa070424a46612794dbb8000194937834250dc723ffa562c876ec/

<img width="949" alt="image" src="https://user-images.githubusercontent.com/2352112/178240447-356982a2-80b0-49a8-9386-4dcbfbcb4582.png">


## Sell Orders
This affects sell orders as shown by the example above

## Buy Orders
This PR shouldn't add any change for these.

Compare: 
* https://pr161--gpui.review.gnosisdev.com/rinkeby/orders/0x84b1db5bf9ca32afe11fffa30a828f26c32d43572ce313b3b3e37c5c38527a9779063d9173c09887d536924e2f6eadbabac099f562f4e1e8 
* https://barn.explorer.cow.fi/rinkeby/orders/0x84b1db5bf9ca32afe11fffa30a828f26c32d43572ce313b3b3e37c5c38527a9779063d9173c09887d536924e2f6eadbabac099f562f4e1e8

## Partial Executions
Should behave as normal sell orders/buy orders. And takes into account the `executedFeeAmount`, so if there's a partial fee payed as part of the partial trades, then the fee is accounted.

Unfortunately I don't have examples on partials with fee, because currently we only have liquidity orders, and this one has 0 fee.

* https://pr161--gpui.review.gnosisdev.com/rinkeby/orders/0x56664645e66881c2f8bd80170fa5607f5ec8505b9719707a20eb5a1f5e4934c4fc78f8e1af80a3bf5a1783bb59ed2d1b10f78ca962ebc313 
* https://barn.explorer.cow.fi/rinkeby/orders/0x56664645e66881c2f8bd80170fa5607f5ec8505b9719707a20eb5a1f5e4934c4fc78f8e1af80a3bf5a1783bb59ed2d1b10f78ca962ebc313



## Context
It just feel that is closer to the users expectations in my opinion. You inform the total amount they pay. They can check the fee anyways if they want to calculate the traded amount without fee, but I don't think a user would want to think in those terms. 

So I'm in favour of this change. But, let's use this PR to get other's opinions