### PR TITLE
Add Goerli support

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.9.12",
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/cow-sdk": "1.0.0-RC.3",
+    "@cowprotocol/cow-sdk": "1.0.0-RC.4",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.9.12",
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/cow-sdk": "^0.0.14",
+    "@cowprotocol/cow-sdk": "^0.0.15",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.9.12",
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/cow-sdk": "^1.0.0",
+    "@cowprotocol/cow-sdk": "1.0.0-RC.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.9.12",
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/cow-sdk": "file:.yalc/@cowprotocol/cow-sdk",
+    "@cowprotocol/cow-sdk": "1.0.0-RC.3",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.9.12",
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/cow-sdk": "1.0.0-RC.0",
+    "@cowprotocol/cow-sdk": "1.0.0-RC.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.9.12",
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/cow-sdk": "^0.0.15",
+    "@cowprotocol/cow-sdk": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.9.12",
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/cow-sdk": "1.0.0-RC.1",
+    "@cowprotocol/cow-sdk": "file:.yalc/@cowprotocol/cow-sdk",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/src/api/tenderly/tenderlyApi.ts
+++ b/src/api/tenderly/tenderlyApi.ts
@@ -25,6 +25,7 @@ function _urlAvailableNetwork(): Partial<Record<Network, string>> {
     [Network.MAINNET]: urlNetwork(Network.MAINNET),
     [Network.RINKEBY]: urlNetwork(Network.RINKEBY),
     [Network.GNOSIS_CHAIN]: urlNetwork(Network.GNOSIS_CHAIN),
+    [Network.GOERLI]: urlNetwork(Network.GOERLI),
   }
 }
 

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -52,7 +52,7 @@ function infuraProvider(networkId: Network): string {
   }
 
   const network = getNetworkFromId(networkId).toLowerCase()
-  console.log({ network })
+
   if (isWebsocketConnection()) {
     return `wss://${network}.infura.io/ws/v3/${INFURA_ID}`
   } else {

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -52,7 +52,7 @@ function infuraProvider(networkId: Network): string {
   }
 
   const network = getNetworkFromId(networkId).toLowerCase()
-
+  console.log({ network })
   if (isWebsocketConnection()) {
     return `wss://${network}.infura.io/ws/v3/${INFURA_ID}`
   } else {
@@ -88,6 +88,7 @@ export function getProviderByNetwork(networkId: Network | null): string | undefi
   switch (networkId) {
     case Network.MAINNET:
     case Network.RINKEBY:
+    case Network.GOERLI:
       return infuraProvider(networkId)
     case Network.GNOSIS_CHAIN:
       return 'https://rpc.gnosischain.com/'

--- a/src/apps/explorer/ExplorerApp.tsx
+++ b/src/apps/explorer/ExplorerApp.tsx
@@ -155,7 +155,7 @@ export const ExplorerApp: React.FC = () => {
           <Switch>
             <Route path="/mainnet" component={RedirectMainnet} />
             <Route path="/xdai" component={RedirectXdai} />
-            <Route path={['/gc', '/rinkeby', '/']} component={AppContent} />
+            <Route path={['/gc', '/rinkeby', '/goerli', '/']} component={AppContent} />
           </Switch>
         </Router>
         {process.env.NODE_ENV === 'development' && <Console />}

--- a/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/SummaryCards.tsx
@@ -6,9 +6,9 @@ import { formatDistanceToNowStrict } from 'date-fns'
 import { Card, CardContent } from 'components/common/Card'
 import { CardRow } from 'components/common/CardRow'
 import { TotalSummaryResponse } from './useGetSummaryData'
-import { abbreviateString } from 'utils'
+import { abbreviateString, getPercentageDifference } from 'utils'
 import { useMediaBreakpoint } from 'hooks/useMediaBreakPoint'
-import { calcDiff, getColorBySign } from 'components/common/Card/card.utils'
+import { getColorBySign } from 'components/common/Card/card.utils'
 import { CopyButton } from 'components/common/CopyButton'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import { numberFormatter } from './utils'
@@ -61,8 +61,9 @@ export function SummaryCards({ summaryData, children }: SummaryCardsProps): JSX.
   const isDesktop = useMediaBreakpoint(['xl', 'lg'])
   const valueTextSize = isDesktop ? DESKTOP_TEXT_SIZE : MOBILE_TEXT_SIZE
   const rowsByCard = isDesktop ? '2row' : '3row'
-  const diffTransactions = (dailyTransactions && calcDiff(dailyTransactions.now, dailyTransactions.before)) || 0
-  const diffFees = (dailyFees && calcDiff(dailyFees.now, dailyFees.before)) || 0
+  const diffTransactions =
+    (dailyTransactions && getPercentageDifference(dailyTransactions.now, dailyTransactions.before)) || 0
+  const diffFees = (dailyFees && getPercentageDifference(dailyFees.now, dailyFees.before)) || 0
 
   return (
     <CardRow>

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/VolumeChart.tsx
@@ -12,9 +12,9 @@ import {
   LogicalRange,
 } from 'lightweight-charts'
 
-import { formatSmart } from 'utils'
+import { formatSmart, getPercentageDifference } from 'utils'
 import Spinner from 'components/common/Spinner'
-import { calcDiff, getColorBySign } from 'components/common/Card/card.utils'
+import { getColorBySign } from 'components/common/Card/card.utils'
 import {
   ChartSkeleton,
   WrapperChart,
@@ -192,7 +192,7 @@ export function VolumeChart({
   const chartContainerRef = useRef<HTMLDivElement>(null)
   const [chartCreated, setChartCreated] = useState<IChartApi | null | undefined>()
   const theme = useTheme()
-  const diffPercentageVolume = currentVolume && changedVolume && calcDiff(currentVolume, changedVolume)
+  const diffPercentageVolume = currentVolume && changedVolume && getPercentageDifference(currentVolume, changedVolume)
   const captionNameColor = getColorBySign(diffPercentageVolume || 0)
   const [crossHairData, setCrossHairData] = useState<CrossHairData | null>(null)
   const network = useNetworkId()

--- a/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/useGetVolumeData.ts
+++ b/src/apps/explorer/components/SummaryCardsWidget/VolumeChart/useGetVolumeData.ts
@@ -38,7 +38,7 @@ export function useGetVolumeData(volumeTimePeriod = VolumePeriod.DAILY): VolumeD
 }
 
 async function getLastHoursData(network: Network): Promise<RawVolumeItem[]> {
-  const data = await COW_SDK[network]?.cowSubgraphApi.getLastHoursVolume(48)
+  const data = await COW_SDK.cowSubgraphApi.getLastHoursVolume(48, { chainId: network })
 
   return (data?.hourlyTotals as RawVolumeItem[]) || []
 }
@@ -52,7 +52,7 @@ async function getLastDaysData(
     [VolumePeriod.MONTHLY]: 30 * 2,
     [VolumePeriod.YEARLY]: 365 * 2,
   }
-  const data = await COW_SDK[network]?.cowSubgraphApi.getLastDaysVolume(days[period])
+  const data = await COW_SDK.cowSubgraphApi.getLastDaysVolume(days[period], { chainId: network })
 
   return (data?.dailyTotals as RawVolumeItem[]) || []
 }

--- a/src/apps/explorer/components/SummaryCardsWidget/useGetSummaryData.ts
+++ b/src/apps/explorer/components/SummaryCardsWidget/useGetSummaryData.ts
@@ -87,7 +87,7 @@ export function useGetSummaryData(): TotalSummaryResponse | undefined {
 
   const fetchAndBuildSummary = useCallback(async () => {
     setSummary((summary) => ({ ...summary, isLoading: true }))
-    COW_SDK[network]?.cowSubgraphApi.runQuery(summaryQuery).then((data: SummaryQuery) => {
+    COW_SDK.cowSubgraphApi.runQuery(summaryQuery, undefined, { chainId: network }).then((data: SummaryQuery) => {
       const summary = buildSummary(data)
       setSummary({ ...summary, isLoading: false })
     })

--- a/src/apps/explorer/const.ts
+++ b/src/apps/explorer/const.ts
@@ -22,7 +22,7 @@ export const DIMENSION_NAMES = {
   [AnalyticsDimension.BROWSER_TYPE]: 'dimension2',
 }
 
-export const NETWORK_ID_SEARCH_LIST = [Network.MAINNET, Network.GNOSIS_CHAIN, Network.RINKEBY]
+export const NETWORK_ID_SEARCH_LIST = [Network.MAINNET, Network.GNOSIS_CHAIN, Network.RINKEBY, Network.GOERLI]
 
 // Estimation heigh of the header + footer space
 export const HEIGHT_HEADER_FOOTER = 257

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -4,7 +4,7 @@ import { COLOURS } from 'styles'
 import { media } from 'theme/styles/media'
 import { ArrowIconCSS } from 'components/icons/cssIcons'
 
-const { fadedGreyishWhiteOpacity, white, gnosisChainColor } = COLOURS
+const { fadedGreyishWhiteOpacity, white, gnosisChainColor, goerliColor } = COLOURS
 
 export const SelectorContainer = styled.div`
   display: flex;
@@ -59,7 +59,7 @@ export const Option = styled.div`
     border-radius: 100%;
     margin-right: 9px;
     &.goerli {
-      background: ${({ theme }): string => theme.yellow2};
+      background: ${(): string => goerliColor};
     }
     &.rinkeby {
       background: ${({ theme }): string => theme.yellow4};
@@ -85,7 +85,7 @@ export const NetworkLabel = styled.span`
   letter-spacing: 0.1rem;
 
   &.goerli {
-    background: ${({ theme }): string => theme.yellow2};
+    background: ${(): string => goerliColor};
     color: ${({ theme }): string => theme.black};
   }
 

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -22,7 +22,7 @@ export const OptionsContainer = styled.div<{ width: number }>`
   z-index: 1;
   margin: 0 auto;
   width: ${(props: { width: number }): string => `${184 + props.width}px`};
-  height: 128px;
+  height: 170px;
   left: 15px;
   top: 54px;
   background: ${({ theme }): string => theme.bg1};
@@ -58,6 +58,9 @@ export const Option = styled.div`
     height: 8px;
     border-radius: 100%;
     margin-right: 9px;
+    &.goerli {
+      background: ${({ theme }): string => theme.yellow2};
+    }
     &.rinkeby {
       background: ${({ theme }): string => theme.yellow4};
     }
@@ -80,6 +83,11 @@ export const NetworkLabel = styled.span`
   text-transform: uppercase;
   font-weight: ${({ theme }): string => theme.fontBold};
   letter-spacing: 0.1rem;
+
+  &.goerli {
+    background: ${({ theme }): string => theme.yellow2};
+    color: ${({ theme }): string => theme.black};
+  }
 
   &.rinkeby {
     background: ${({ theme }): string => theme.yellow4};

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -58,7 +58,7 @@ export const Option = styled.div`
     height: 8px;
     border-radius: 100%;
     margin-right: 9px;
-    &.goerli {
+    &.görli {
       background: ${(): string => goerliColor};
     }
     &.rinkeby {
@@ -84,7 +84,7 @@ export const NetworkLabel = styled.span`
   font-weight: ${({ theme }): string => theme.fontBold};
   letter-spacing: 0.1rem;
 
-  &.goerli {
+  &.görli {
     background: ${(): string => goerliColor};
     color: ${({ theme }): string => theme.black};
   }

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -36,7 +36,7 @@ export const networkOptions: NetworkOptions[] = [
   },
   {
     id: Network.GOERLI,
-    name: 'Goerli',
+    name: 'Görli',
     url: 'goerli',
   },
 ]

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -34,6 +34,11 @@ export const networkOptions: NetworkOptions[] = [
     name: 'Rinkeby',
     url: 'rinkeby',
   },
+  {
+    id: Network.GOERLI,
+    name: 'Goerli',
+    url: 'goerli',
+  },
 ]
 
 export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) => {

--- a/src/components/common/Card/card.utils.ts
+++ b/src/components/common/Card/card.utils.ts
@@ -1,9 +1,5 @@
 type ThemeColor = 'green' | 'red1' | 'grey'
 
-export function calcDiff(a: number, b: number): number {
-  return (a - b === 0 ? 0 : (100 * (a - b)) / b) || 0
-}
-
 export function getColorBySign(n: number): ThemeColor {
   if (n > 0) {
     return 'green'

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -27,7 +27,7 @@ import { faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
 import { getCidHashFromAppData, getDecodedAppData } from 'hooks/useAppData'
 import useSafeState from 'hooks/useSafeState'
 import { useNetworkId } from 'state/network'
-import { AppDataDoc } from '@cowprotocol/cow-sdk'
+import { LatestAppDataDocVersion } from '@cowprotocol/cow-sdk'
 import { DEFAULT_IPFS_READ_URI, IPFS_INVALID_APP_IDS } from 'const'
 
 const Table = styled(SimpleTable)`
@@ -221,7 +221,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
   } = order
   const [appDataLoading, setAppDataLoading] = useSafeState(false)
   const [appDataError, setAppDataError] = useSafeState(false)
-  const [decodedAppData, setDecodedAppData] = useSafeState<AppDataDoc | void | undefined>(undefined)
+  const [decodedAppData, setDecodedAppData] = useSafeState<LatestAppDataDocVersion | void | undefined>(undefined)
   const [ipfsUri, setIpfsUri] = useSafeState<string>('')
 
   const [showDecodedAppData, setShowDecodedAppData] = useSafeState<boolean>(false)

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -27,7 +27,7 @@ import { faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
 import { getCidHashFromAppData, getDecodedAppData } from 'hooks/useAppData'
 import useSafeState from 'hooks/useSafeState'
 import { useNetworkId } from 'state/network'
-import { LatestAppDataDocVersion } from '@cowprotocol/cow-sdk'
+import { AnyAppDataDocVersion } from '@cowprotocol/cow-sdk'
 import { DEFAULT_IPFS_READ_URI, IPFS_INVALID_APP_IDS } from 'const'
 
 const Table = styled(SimpleTable)`
@@ -221,7 +221,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
   } = order
   const [appDataLoading, setAppDataLoading] = useSafeState(false)
   const [appDataError, setAppDataError] = useSafeState(false)
-  const [decodedAppData, setDecodedAppData] = useSafeState<LatestAppDataDocVersion | void | undefined>(undefined)
+  const [decodedAppData, setDecodedAppData] = useSafeState<AnyAppDataDocVersion | void | undefined>(undefined)
   const [ipfsUri, setIpfsUri] = useSafeState<string>('')
 
   const [showDecodedAppData, setShowDecodedAppData] = useSafeState<boolean>(false)

--- a/src/const.ts
+++ b/src/const.ts
@@ -228,35 +228,19 @@ export const DISABLED_TOKEN_MAPS = Object.keys(disabledTokens).reduce<DisabledTo
   },
 )
 
-export const COW_SDK = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN, Network.GOERLI].reduce<
-  Record<number, CowSdk<SupportedChainId> | null>
->((acc, networkId) => {
-  try {
-    acc[networkId] = new CowSdk(networkId)
-  } catch (error) {
-    console.error('Instantiating CowSdk failed', error)
-  }
+export const COW_SDK: Record<SupportedChainId, CowSdk<SupportedChainId>> = {
+  [Network.MAINNET]: new CowSdk(Network.MAINNET),
+  [Network.RINKEBY]: new CowSdk(Network.RINKEBY),
+  [Network.GOERLI]: new CowSdk(Network.GOERLI),
+  [Network.GNOSIS_CHAIN]: new CowSdk(Network.GNOSIS_CHAIN),
+}
 
-  console.info(`CowSdk initialized on chain ${networkId}`)
-
-  return acc
-}, {})
-
-export const COW_SDK_DEV = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN, Network.GOERLI].reduce<
-  Record<number, CowSdk<SupportedChainId> | null>
->((acc, networkId) => {
-  try {
-    acc[networkId] = new CowSdk(networkId, {
-      isDevEnvironment: true,
-    })
-  } catch (error) {
-    console.error('Instantiating CowSdk in development mode failed', error)
-  }
-
-  console.info(`CowSdk in development mode initialized on chain ${networkId}`)
-
-  return acc
-}, {})
+export const COW_SDK_DEV: Record<SupportedChainId, CowSdk<SupportedChainId>> = {
+  [Network.MAINNET]: new CowSdk(Network.MAINNET, { env: 'staging' }),
+  [Network.RINKEBY]: new CowSdk(Network.RINKEBY, { env: 'staging' }),
+  [Network.GOERLI]: new CowSdk(Network.GOERLI, { env: 'staging' }),
+  [Network.GNOSIS_CHAIN]: new CowSdk(Network.GNOSIS_CHAIN, { env: 'staging' }),
+}
 
 export const ETH: TokenErc20 = {
   name: 'ETH',

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import BN from 'bn.js'
-import { CowSdk, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CowSdk } from '@cowprotocol/cow-sdk'
 import { TokenErc20, UNLIMITED_ORDER_AMOUNT, BATCH_TIME } from '@gnosis.pm/dex-js'
 export {
   UNLIMITED_ORDER_AMOUNT,
@@ -228,19 +228,7 @@ export const DISABLED_TOKEN_MAPS = Object.keys(disabledTokens).reduce<DisabledTo
   },
 )
 
-export const COW_SDK: Record<SupportedChainId, CowSdk<SupportedChainId>> = {
-  [Network.MAINNET]: new CowSdk(Network.MAINNET),
-  [Network.RINKEBY]: new CowSdk(Network.RINKEBY),
-  [Network.GOERLI]: new CowSdk(Network.GOERLI),
-  [Network.GNOSIS_CHAIN]: new CowSdk(Network.GNOSIS_CHAIN),
-}
-
-export const COW_SDK_DEV: Record<SupportedChainId, CowSdk<SupportedChainId>> = {
-  [Network.MAINNET]: new CowSdk(Network.MAINNET, { env: 'staging' }),
-  [Network.RINKEBY]: new CowSdk(Network.RINKEBY, { env: 'staging' }),
-  [Network.GOERLI]: new CowSdk(Network.GOERLI, { env: 'staging' }),
-  [Network.GNOSIS_CHAIN]: new CowSdk(Network.GNOSIS_CHAIN, { env: 'staging' }),
-}
+export const COW_SDK = new CowSdk(Network.MAINNET)
 
 export const ETH: TokenErc20 = {
   name: 'ETH',

--- a/src/const.ts
+++ b/src/const.ts
@@ -224,10 +224,11 @@ export const DISABLED_TOKEN_MAPS = Object.keys(disabledTokens).reduce<DisabledTo
     [Network.MAINNET]: {},
     [Network.RINKEBY]: {},
     [Network.GNOSIS_CHAIN]: {},
+    [Network.GOERLI]: {},
   },
 )
 
-export const COW_SDK = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN].reduce<
+export const COW_SDK = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN, Network.GOERLI].reduce<
   Record<number, CowSdk<SupportedChainId> | null>
 >((acc, networkId) => {
   try {
@@ -241,7 +242,7 @@ export const COW_SDK = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN].
   return acc
 }, {})
 
-export const COW_SDK_DEV = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN].reduce<
+export const COW_SDK_DEV = [Network.MAINNET, Network.RINKEBY, Network.GNOSIS_CHAIN, Network.GOERLI].reduce<
   Record<number, CowSdk<SupportedChainId> | null>
 >((acc, networkId) => {
   try {
@@ -274,6 +275,7 @@ export const XDAI: TokenErc20 = {
 export const NATIVE_TOKEN_PER_NETWORK: Record<string, TokenErc20> = {
   '1': ETH,
   '4': ETH,
+  '5': ETH,
   '100': XDAI,
 }
 

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react'
-import { LatestAppDataDocVersion } from '@cowprotocol/cow-sdk'
+import { AnyAppDataDocVersion } from '@cowprotocol/cow-sdk'
 import { useNetworkId } from 'state/network'
 import { COW_SDK } from 'const'
 import { Network } from 'types'
 
 export const useAppData = (
   appDataHash: string,
-): { isLoading: boolean; appDataDoc: LatestAppDataDocVersion | void | undefined } => {
+): { isLoading: boolean; appDataDoc: AnyAppDataDocVersion | void | undefined } => {
   const network = useNetworkId() || undefined
   const [isLoading, setLoading] = useState<boolean>(false)
-  const [appDataDoc, setAppDataDoc] = useState<LatestAppDataDocVersion | void>()
+  const [appDataDoc, setAppDataDoc] = useState<AnyAppDataDocVersion | void>()
   useEffect(() => {
     async function getAppDataDoc(): Promise<void> {
       setLoading(true)
@@ -33,7 +33,7 @@ export const useAppData = (
 export const getDecodedAppData = (
   appDataHash: string,
   networkId = Network.MAINNET,
-): Promise<void | AppDataDoc> | undefined => {
+): Promise<void | AnyAppDataDocVersion> | undefined => {
   return COW_SDK[networkId]?.metadataApi.decodeAppData(appDataHash)
 }
 

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
-import { AppDataDoc } from '@cowprotocol/cow-sdk'
+import { LatestAppDataDocVersion } from '@cowprotocol/cow-sdk'
 import { useNetworkId } from 'state/network'
 import { COW_SDK } from 'const'
 import { Network } from 'types'
 
-export const useAppData = (appDataHash: string): { isLoading: boolean; appDataDoc: AppDataDoc | void | undefined } => {
+export const useAppData = (
+  appDataHash: string,
+): { isLoading: boolean; appDataDoc: LatestAppDataDocVersion | void | undefined } => {
   const network = useNetworkId() || undefined
   const [isLoading, setLoading] = useState<boolean>(false)
-  const [appDataDoc, setAppDataDoc] = useState<AppDataDoc | void>()
+  const [appDataDoc, setAppDataDoc] = useState<LatestAppDataDocVersion | void>()
   useEffect(() => {
     async function getAppDataDoc(): Promise<void> {
       setLoading(true)

--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -6,7 +6,7 @@ import { COW_SDK, NATIVE_TOKEN_PER_NETWORK } from 'const'
 import { TableState } from 'apps/explorer/components/TokensTableWidget/useTable'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 import { UTCTimestamp } from 'lightweight-charts'
-import { isNativeToken } from 'utils'
+import { getPercentageDifference, isNativeToken } from 'utils'
 
 export function useGetTokens(networkId: Network | undefined, tableState: TableState): GetTokensResult {
   const [isLoading, setIsLoading] = useState(false)
@@ -265,10 +265,6 @@ export type TokenData = {
   lastDayPricePercentageDifference?: number
   lastWeekPricePercentageDifference?: number
   lastWeekUsdPrices?: Array<{ time: UTCTimestamp; value: number }>
-}
-
-function getPercentageDifference(a: number, b: number): number {
-  return a ? ((a - b) / a) * 100 : 0
 }
 
 function lastHoursTimestamp(n: number): string {

--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -20,7 +20,11 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
       setTokens([])
       setHistoricalDataLoaded({})
       try {
-        const response = await COW_SDK[network]?.cowSubgraphApi.runQuery<{ tokens: TokenResponse[] }>(GET_TOKENS_QUERY)
+        const response = await COW_SDK.cowSubgraphApi.runQuery<{ tokens: TokenResponse[] }>(
+          GET_TOKENS_QUERY,
+          undefined,
+          { chainId: network },
+        )
         if (response) {
           const tokens = enhanceNativeToken(response.tokens, network)
           setTokens(tokens)
@@ -37,24 +41,26 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
   )
 
   const getTokens = useCallback(
-    (
-      network: Network,
-      tokenIds: string[],
-    ): { [tokenId: string]: Promise<SubgraphHistoricalDataResponse> | undefined } => {
+    (tokenIds: string[]): { [tokenId: string]: Promise<SubgraphHistoricalDataResponse> | undefined } => {
       const lastDayTimestamp = Number(lastHoursTimestamp(25)) // last 25 hours
       const lastWeekTimestamp = Number(lastDaysTimestamp(8)) // last 8 days
       const responses = {}
       for (const tokenId of tokenIds) {
-        const response = COW_SDK[network]?.cowSubgraphApi.runQuery<SubgraphHistoricalDataResponse>(
+        const response = COW_SDK.cowSubgraphApi.runQuery<SubgraphHistoricalDataResponse>(
           GET_HISTORICAL_DATA_QUERY,
-          { address: tokenId, lastDayTimestamp, lastWeekTimestamp },
+          {
+            address: tokenId,
+            lastDayTimestamp,
+            lastWeekTimestamp,
+          },
+          { chainId: networkId },
         )
         responses[tokenId] = response
       }
 
       return responses
     },
-    [],
+    [networkId],
   )
 
   const processTokenData = useCallback((data: SubgraphHistoricalDataResponse) => {
@@ -90,10 +96,10 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
   }, [])
 
   const getTokensHistoricalData = useCallback(
-    async (network: Network, tokenIds: string[]): Promise<{ [tokenId: string]: TokenData } | void> => {
+    async (tokenIds: string[]): Promise<{ [tokenId: string]: TokenData } | void> => {
       setIsLoading(true)
       try {
-        const tokens = await getTokens(network, tokenIds)
+        const tokens = await getTokens(tokenIds)
         const tokensData = {} as { [tokenId: string]: TokenData }
 
         for (const address of Object.keys(tokens)) {
@@ -138,7 +144,7 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
     const tokenIds = pageTokens.map((token) => token.id)
 
     const setHistoricalData = async function (): Promise<void> {
-      const historicalData = await getTokensHistoricalData(networkId, tokenIds)
+      const historicalData = await getTokensHistoricalData(tokenIds)
 
       if (historicalData) {
         setTokens((tokens) => [...addHistoricalData(tokens, historicalData)])

--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -1,3 +1,4 @@
+import { TradeMetaData } from '@cowprotocol/cow-sdk'
 import { getTrades, Order, Trade } from 'api/operator'
 import { useCallback, useEffect, useState } from 'react'
 import { useNetworkId } from 'state/network'
@@ -34,7 +35,12 @@ export function useTrades(params: Params): Result {
     setIsLoading(true)
 
     try {
-      const trades = await getTrades({ networkId, owner, orderId })
+      let trades: TradeMetaData[] = []
+      if (orderId) {
+        trades = await getTrades({ networkId, orderId })
+      } else if (owner) {
+        trades = await getTrades({ networkId, owner })
+      }
 
       // TODO: fetch buy/sellToken objects
       setTrades(trades.map((trade) => transformTrade(trade)))

--- a/src/state/network/updater.tsx
+++ b/src/state/network/updater.tsx
@@ -14,6 +14,7 @@ const NETWORK_PREFIXES_RAW: [Network, string][] = [
   [Network.MAINNET, ''],
   [Network.GNOSIS_CHAIN, 'gc'],
   [Network.RINKEBY, 'rinkeby'],
+  [Network.RINKEBY, 'goerli'],
 ]
 export const PREFIX_BY_NETWORK_ID: Map<Network, string> = new Map(NETWORK_PREFIXES_RAW)
 const NETWORK_ID_BY_PREFIX: Map<string, Network> = new Map(NETWORK_PREFIXES_RAW.map(([key, value]) => [value, key]))
@@ -35,7 +36,7 @@ function getNetworkPrefix(network: Network): string {
  */
 export const useDecomposedPath = (): [string, string] | [] => {
   const { pathname } = useLocation()
-  const pathMatchArray = pathname.match('/(rinkeby|xdai|mainnet|gc)?/?(.*)')
+  const pathMatchArray = pathname.match('/(rinkeby|xdai|mainnet|gc|goerli)?/?(.*)')
 
   return pathMatchArray == null ? [] : [pathMatchArray[1], pathMatchArray[2]]
 }
@@ -89,7 +90,7 @@ export const NetworkUpdater: React.FC = () => {
   const location = useLocation()
 
   useEffect(() => {
-    const networkMatchArray = location.pathname.match('^/(rinkeby|gc)')
+    const networkMatchArray = location.pathname.match('^/(rinkeby|gc|goerli)')
     const network = networkMatchArray && networkMatchArray.length > 0 ? networkMatchArray[1] : undefined
     const networkId = getNetworkId(network)
 

--- a/src/state/network/updater.tsx
+++ b/src/state/network/updater.tsx
@@ -14,7 +14,7 @@ const NETWORK_PREFIXES_RAW: [Network, string][] = [
   [Network.MAINNET, ''],
   [Network.GNOSIS_CHAIN, 'gc'],
   [Network.RINKEBY, 'rinkeby'],
-  [Network.RINKEBY, 'goerli'],
+  [Network.GOERLI, 'goerli'],
 ]
 export const PREFIX_BY_NETWORK_ID: Map<Network, string> = new Map(NETWORK_PREFIXES_RAW)
 const NETWORK_ID_BY_PREFIX: Map<string, Network> = new Map(NETWORK_PREFIXES_RAW.map(([key, value]) => [value, key]))

--- a/src/styles/colours.ts
+++ b/src/styles/colours.ts
@@ -4,6 +4,7 @@ export const COLOURS = {
   blue: '#3F77FF',
   blueDark: '#185afb',
   gnosisChainColor: '#07795b',
+  goerliColor: 'rgb(47, 153, 242)',
   purple: '#8958FF',
   bgLight: '#edf2f7',
   bgDark: 'linear-gradient(0deg, #21222E 0.05%, #2C2D3F 100%)',

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -295,3 +295,14 @@ export function cleanNetworkName(networkName: string | undefined): string {
 
   return networkName.replace(/\s+/g, '').toLowerCase()
 }
+/**
+ * Returns the difference in percentage between two numbers
+ *
+ * @export
+ * @param {number} a
+ * @param {number} b
+ * @return {*}  {number}
+ */
+export function getPercentageDifference(a: number, b: number): number {
+  return b ? ((a - b) / b) * 100 : 0
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,9 +27,11 @@ const EXPLORER_APP = {
 
     OPERATOR_URL_STAGING_MAINNET: 'https://barn.api.cow.fi/mainnet/api',
     OPERATOR_URL_STAGING_RINKEBY: 'https://barn.api.cow.fi/rinkeby/api',
+    OPERATOR_URL_STAGING_GOERLI: 'https://barn.api.cow.fi/goerli/api',
     OPERATOR_URL_STAGING_XDAI: 'https://barn.api.cow.fi/xdai/api',
     OPERATOR_URL_PROD_MAINNET: 'https://api.cow.fi/mainnet/api',
     OPERATOR_URL_PROD_RINKEBY: 'https://api.cow.fi/rinkeby/api',
+    OPERATOR_URL_PROD_GOERLI: 'https://api.cow.fi/goerli/api',
     OPERATOR_URL_PROD_XDAI: 'https://api.cow.fi/xdai/api',
 
     GOOGLE_ANALYTICS_ID: undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,10 +1279,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@1.0.0-RC.3":
-  version "1.0.0-RC.3"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.3.tgz#b6bf78cbb6e66e95804679ab5b92f49da1a82d05"
-  integrity sha512-Jef69munoKMBmMOgZ+5P9oa6VzDHO61Bn61banmtPhVfaRwiC9GpkySFH9Q/5D2eBmQssP0cAmQSShe3nDchbw==
+"@cowprotocol/cow-sdk@1.0.0-RC.4":
+  version "1.0.0-RC.4"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.4.tgz#cf34cd013cfdec3757a0ea412c22b6ffae9bc72e"
+  integrity sha512-iqygyhSzL6Ai/4y792c+czit88eKp8mgoF3F64WMKKo5kh/kZOkm3sbudz+i//hrP5ouDUOz5FbJBRDajT9wCw==
   dependencies:
     "@cowprotocol/app-data" "^0.0.1-RC.3"
     "@cowprotocol/contracts" "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,10 +1267,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cowprotocol/app-data@^0.0.1-RC.1":
-  version "0.0.1-RC.2"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.1-RC.2.tgz#0cde63b2efa9b36046c5c4c37e2ab72b9efe93d3"
-  integrity sha512-wA6DRCTStN+whPkawwRctAjUKlBXFrrAiysYIqsM02Vj0AuyhfygRBxRHG9g2vyssqR3dIYNQkJkserNyHX+pg==
+"@cowprotocol/app-data@^0.0.1-RC.3":
+  version "0.0.1-RC.3"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.1-RC.3.tgz#929341c4a74dedff86dc416be1be3d3e5d29d26e"
+  integrity sha512-BarRIuuI0cO8YbQDR+wuhygZ5PhxYdtlkNisbBKPbSNm9y0gvt3sKND7jli1YUfvegXbtKAwa6zsKJOgvgtE8g==
   dependencies:
     ajv "^8.11.0"
 
@@ -1279,14 +1279,13 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@1.0.0-RC.0":
-  version "1.0.0-RC.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.0.tgz#acadbaf46f8538665a55d84daed8bf4976f33a94"
-  integrity sha512-84GZNRFxl8ZJe6ZNGX6BlMj/UIZ9mwylaJv8HIJN3eEUnXGwZE48NElOQMINa4OaQv49cxh2C4K77E6HU9PiCQ==
+"@cowprotocol/cow-sdk@1.0.0-RC.1":
+  version "1.0.0-RC.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.1.tgz#5762c1ca2ee4b1a024cc63483f1f752d750412c1"
+  integrity sha512-L7hQiOKY3KM79MbmYhipyvI513jaJLJJNGerUsprY7y0UvlVO5KI9/F0TsAZcjeCTX9le7lS1HsHWaqoVPpH9g==
   dependencies:
-    "@cowprotocol/app-data" "^0.0.1-RC.1"
+    "@cowprotocol/app-data" "^0.0.1-RC.3"
     "@cowprotocol/contracts" "^1.3.1"
-    ajv "^8.8.2"
     cross-fetch "^3.1.5"
     ethers "^5.5.3"
     graphql "^16.3.0"
@@ -1294,6 +1293,8 @@
     ipfs-only-hash "^4.0.0"
     loglevel "^1.8.0"
     multiformats "^9.6.4"
+    paraswap "^5.2.0"
+    paraswap-core "^1.0.2"
 
 "@date-io/core@^2.11.0":
   version "2.11.0"
@@ -1444,6 +1445,22 @@
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
+
+"@ethereumjs/common@^2.5.0", "@ethereumjs/common@^2.6.4":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.6.5.tgz#0a75a22a046272579d91919cb12d84f2756e8d30"
+  integrity sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.5"
+
+"@ethereumjs/tx@^3.3.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.5.2.tgz#197b9b6299582ad84f9527ca961466fce2296c1c"
+  integrity sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==
+  dependencies:
+    "@ethereumjs/common" "^2.6.4"
+    ethereumjs-util "^7.1.5"
 
 "@ethersproject/abi@5.0.0-beta.153":
   version "5.0.0-beta.153"
@@ -4417,6 +4434,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
+"@types/node@^12.12.6":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
 "@types/node@^12.6.1":
   version "12.20.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.19.tgz#538e61fc220f77ae4a4663c3d8c3cb391365c209"
@@ -5340,7 +5362,7 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ajv@^8.11.0, ajv@^8.8.2:
+ajv@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
@@ -5738,6 +5760,11 @@ async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.5.0, async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+async@^3.1.0:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -5771,6 +5798,11 @@ autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
 await-semaphore@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/await-semaphore/-/await-semaphore-0.1.3.tgz#2b88018cc8c28e06167ae1cdff02504f1f9688d3"
@@ -5785,6 +5817,13 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+axios@0.21.2:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
+  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+  dependencies:
+    follow-redirects "^1.14.0"
 
 axios@^0.21.1:
   version "0.21.4"
@@ -6112,6 +6151,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+bignumber.js@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
+  integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
 
 bignumber.js@^2.1.0:
   version "2.4.0"
@@ -7669,6 +7713,11 @@ cpy@^8.1.1:
     p-filter "^2.1.0"
     p-map "^3.0.0"
 
+crc-32@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
+
 crc-32@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
@@ -8302,6 +8351,14 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+define-properties@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -9023,6 +9080,35 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
 
+es-abstract@^1.19.5, es-abstract@^1.20.0:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
+  integrity sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    regexp.prototype.flags "^1.4.3"
+    string.prototype.trimend "^1.0.5"
+    string.prototype.trimstart "^1.0.5"
+    unbox-primitive "^1.0.2"
+
 es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
@@ -9530,6 +9616,15 @@ eth-lib@0.2.7:
     elliptic "^6.4.0"
     xhr-request-promise "^0.1.2"
 
+eth-lib@0.2.8, eth-lib@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/eth-lib/-/eth-lib-0.2.8.tgz#b194058bef4b220ad12ea497431d6cb6aa0623c8"
+  integrity sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==
+  dependencies:
+    bn.js "^4.11.6"
+    elliptic "^6.4.0"
+    xhr-request-promise "^0.1.2"
+
 eth-lib@^0.1.26:
   version "0.1.29"
   resolved "https://registry.yarnpkg.com/eth-lib/-/eth-lib-0.1.29.tgz#0c11f5060d42da9f931eab6199084734f4dbd1d9"
@@ -9540,15 +9635,6 @@ eth-lib@^0.1.26:
     nano-json-stream-parser "^0.1.2"
     servify "^0.1.12"
     ws "^3.0.0"
-    xhr-request-promise "^0.1.2"
-
-eth-lib@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/eth-lib/-/eth-lib-0.2.8.tgz#b194058bef4b220ad12ea497431d6cb6aa0623c8"
-  integrity sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==
-  dependencies:
-    bn.js "^4.11.6"
-    elliptic "^6.4.0"
     xhr-request-promise "^0.1.2"
 
 eth-query@^2.1.0, eth-query@^2.1.2:
@@ -9709,6 +9795,17 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.5:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz#9ecf04861e4fbbeed7465ece5f23317ad1129181"
+  integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    rlp "^2.2.4"
+
 ethereumjs-util@^7.0.2:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz#e2b43a30bfcdbcb432a4eb42bd5f2393209b3fd5"
@@ -9865,6 +9962,11 @@ eventemitter3@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
+eventemitter3@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
+  integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
 
 eventemitter3@4.0.7, eventemitter3@^4.0.0:
   version "4.0.7"
@@ -10833,6 +10935,16 @@ function.prototype.name@^1.1.0, function.prototype.name@^1.1.2, function.prototy
     es-abstract "^1.18.0-next.2"
     functions-have-names "^1.2.2"
 
+function.prototype.name@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
+  integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    functions-have-names "^1.2.2"
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
@@ -11341,6 +11453,11 @@ has-bigints@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
 
+has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -11358,6 +11475,13 @@ has-glob@^1.0.0:
   dependencies:
     is-glob "^3.0.0"
 
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
@@ -11367,6 +11491,11 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
@@ -12455,6 +12584,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-gif@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-gif/-/is-gif-3.0.0.tgz#c4be60b26a301d695bb833b20d9b5d66c6cf83b1"
@@ -12524,6 +12660,11 @@ is-negative-zero@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-negative-zero@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-number-object@^1.0.4:
   version "1.0.6"
@@ -12633,6 +12774,13 @@ is-shared-array-buffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
   integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -12669,6 +12817,17 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
+is-typed-array@^1.1.3, is-typed-array@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.9.tgz#246d77d2871e7d9f5aeb1d54b9f52c71329ece67"
+  integrity sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.20.0"
+    for-each "^0.3.3"
+    has-tostringtag "^1.0.0"
+
 is-typedarray@1.0.0, is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -12697,6 +12856,13 @@ is-weakref@^1.0.1:
   integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
   dependencies:
     call-bind "^1.0.0"
+
+is-weakref@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-whitespace-character@^1.0.0:
   version "1.0.4"
@@ -14176,7 +14342,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.x, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@4.x, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -15450,6 +15616,11 @@ object-inspect@^1.11.0, object-inspect@^1.6.0, object-inspect@^1.7.0, object-ins
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
   integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
 
+object-inspect@^1.12.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+
 object-is@^1.0.1, object-is@^1.0.2, object-is@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
@@ -15545,6 +15716,13 @@ oboe@2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/oboe/-/oboe-2.1.4.tgz#20c88cdb0c15371bb04119257d4fdd34b0aa49f6"
   integrity sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=
+  dependencies:
+    http-https "^1.0.0"
+
+oboe@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/oboe/-/oboe-2.1.5.tgz#5554284c543a2266d7a38f17e073821fbde393cd"
+  integrity sha512-zRFWiF+FoicxEs3jNI/WYUrVEgA7DeET/InK0XQuudGHRg8iIob3cNPrJTKaz4004uaA9Pbe+Dwa8iluhjLZWA==
   dependencies:
     http-https "^1.0.0"
 
@@ -15895,6 +16073,25 @@ param-case@^3.0.3:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
+
+paraswap-core@1.0.2, paraswap-core@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/paraswap-core/-/paraswap-core-1.0.2.tgz#9e2ae35bc393b6f3bb9407bd097f21d498abb5a7"
+  integrity sha512-/PyonrjBsv9xOsFk4mVr0rh7BENrQtYYvvZMwu6QFN4qcca2VgmqOgpNWZPvfyBpKY+fUqmbBNlhqlaMQ3TMzQ==
+
+paraswap@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/paraswap/-/paraswap-5.2.0.tgz#07649e4cc18e911f01629d52efeca85596c79db1"
+  integrity sha512-SYGhP7/ReHPwyLmCUuHh3mHqSK91r7HRcAs8siE7xOZ+omcUsyRwmvnlK9L5jsIwXkYZ/Rn6q3BTwCTLmw+4bA==
+  dependencies:
+    async "^3.1.0"
+    axios "0.21.2"
+    bignumber.js "8.1.1"
+    lodash "4.17.21"
+    paraswap-core "1.0.2"
+    qs "^6.9.1"
+    ts-essentials "^7.0.0"
+    web3 "^1.5.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -16919,6 +17116,13 @@ qs@^6.10.0:
   dependencies:
     side-channel "^1.0.4"
 
+qs@^6.9.1:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -17642,6 +17846,15 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.1:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+regexp.prototype.flags@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    functions-have-names "^1.2.2"
 
 regexpp@^3.1.0:
   version "3.2.0"
@@ -19119,6 +19332,15 @@ string.prototype.trimend@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string.prototype.trimend@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
+  integrity sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
+
 string.prototype.trimstart@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
@@ -19126,6 +19348,15 @@ string.prototype.trimstart@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
+  integrity sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
@@ -19910,6 +20141,11 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
+ts-essentials@^7.0.0:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
+
 ts-invariant@^0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.1.tgz#87dfde9894a4ce3c7711b02b1b449e7fd7384b13"
@@ -20131,6 +20367,16 @@ unbox-primitive@^1.0.1:
     function-bind "^1.1.1"
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
+  dependencies:
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
 unbzip2-stream@^1.0.9:
@@ -20532,6 +20778,18 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.0:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
+  integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    safe-buffer "^5.1.2"
+    which-typed-array "^1.1.2"
+
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -20741,6 +20999,15 @@ web3-bzz@1.2.9:
     swarm-js "^0.1.40"
     underscore "1.9.1"
 
+web3-bzz@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.7.4.tgz#9419e606e38a9777443d4ce40506ebd796e06075"
+  integrity sha512-w9zRhyEqTK/yi0LGRHjZMcPCfP24LBjYXI/9YxFw9VqsIZ9/G0CRCnUt12lUx0A56LRAMpF7iQ8eA73aBcO29Q==
+  dependencies:
+    "@types/node" "^12.12.6"
+    got "9.6.0"
+    swarm-js "^0.1.40"
+
 web3-core-helpers@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.2.9.tgz#6381077c3e01c127018cb9e9e3d1422697123315"
@@ -20749,6 +21016,14 @@ web3-core-helpers@1.2.9:
     underscore "1.9.1"
     web3-eth-iban "1.2.9"
     web3-utils "1.2.9"
+
+web3-core-helpers@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.7.4.tgz#f8f808928560d3e64e0c8d7bdd163aa4766bcf40"
+  integrity sha512-F8PH11qIkE/LpK4/h1fF/lGYgt4B6doeMi8rukeV/s4ivseZHHslv1L6aaijLX/g/j4PsFmR42byynBI/MIzFg==
+  dependencies:
+    web3-eth-iban "1.7.4"
+    web3-utils "1.7.4"
 
 web3-core-method@1.2.9:
   version "1.2.9"
@@ -20762,12 +21037,30 @@ web3-core-method@1.2.9:
     web3-core-subscriptions "1.2.9"
     web3-utils "1.2.9"
 
+web3-core-method@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.7.4.tgz#3873c6405e1a0a8a1efc1d7b28de8b7550b00c15"
+  integrity sha512-56K7pq+8lZRkxJyzf5MHQPI9/VL3IJLoy4L/+q8HRdZJ3CkB1DkXYaXGU2PeylG1GosGiSzgIfu1ljqS7CP9xQ==
+  dependencies:
+    "@ethersproject/transactions" "^5.6.2"
+    web3-core-helpers "1.7.4"
+    web3-core-promievent "1.7.4"
+    web3-core-subscriptions "1.7.4"
+    web3-utils "1.7.4"
+
 web3-core-promievent@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.9.tgz#bb1c56aa6fac2f4b3c598510f06554d25c11c553"
   integrity sha512-0eAUA2zjgXTleSrnc1wdoKQPPIHU6KHf4fAscu4W9kKrR+mqP1KsjYrxY9wUyjNnXxfQ+5M29ipvbiaK8OqdOw==
   dependencies:
     eventemitter3 "3.1.2"
+
+web3-core-promievent@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.7.4.tgz#80a75633fdfe21fbaae2f1e38950edb2f134868c"
+  integrity sha512-o4uxwXKDldN7ER7VUvDfWsqTx9nQSP1aDssi1XYXeYC2xJbVo0n+z6ryKtmcoWoRdRj7uSpVzal3nEmlr480mA==
+  dependencies:
+    eventemitter3 "4.0.4"
 
 web3-core-requestmanager@1.2.9:
   version "1.2.9"
@@ -20780,6 +21073,17 @@ web3-core-requestmanager@1.2.9:
     web3-providers-ipc "1.2.9"
     web3-providers-ws "1.2.9"
 
+web3-core-requestmanager@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.7.4.tgz#2dc8a526dab8183dca3fef54658621801b1d0469"
+  integrity sha512-IuXdAm65BQtPL4aI6LZJJOrKAs0SM5IK2Cqo2/lMNvVMT9Kssq6qOk68Uf7EBDH0rPuINi+ReLP+uH+0g3AnPA==
+  dependencies:
+    util "^0.12.0"
+    web3-core-helpers "1.7.4"
+    web3-providers-http "1.7.4"
+    web3-providers-ipc "1.7.4"
+    web3-providers-ws "1.7.4"
+
 web3-core-subscriptions@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.2.9.tgz#335fd7d15dfce5d78b4b7bef05ce4b3d7237b0e4"
@@ -20788,6 +21092,14 @@ web3-core-subscriptions@1.2.9:
     eventemitter3 "3.1.2"
     underscore "1.9.1"
     web3-core-helpers "1.2.9"
+
+web3-core-subscriptions@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.7.4.tgz#cfbd3fa71081a8c8c6f1a64577a1a80c5bd9826f"
+  integrity sha512-VJvKWaXRyxk2nFWumOR94ut9xvjzMrRtS38c4qj8WBIRSsugrZr5lqUwgndtj0qx4F+50JhnU++QEqUEAtKm3g==
+  dependencies:
+    eventemitter3 "4.0.4"
+    web3-core-helpers "1.7.4"
 
 web3-core@1.2.9:
   version "1.2.9"
@@ -20802,6 +21114,19 @@ web3-core@1.2.9:
     web3-core-requestmanager "1.2.9"
     web3-utils "1.2.9"
 
+web3-core@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.7.4.tgz#943fff99134baedafa7c65b4a0bbd424748429ff"
+  integrity sha512-L0DCPlIh9bgIED37tYbe7bsWrddoXYc897ANGvTJ6MFkSNGiMwDkTLWSgYd9Mf8qu8b4iuPqXZHMwIo4atoh7Q==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    "@types/node" "^12.12.6"
+    bignumber.js "^9.0.0"
+    web3-core-helpers "1.7.4"
+    web3-core-method "1.7.4"
+    web3-core-requestmanager "1.7.4"
+    web3-utils "1.7.4"
+
 web3-eth-abi@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.2.9.tgz#14bedd7e4be04fcca35b2ac84af1400574cd8280"
@@ -20810,6 +21135,14 @@ web3-eth-abi@1.2.9:
     "@ethersproject/abi" "5.0.0-beta.153"
     underscore "1.9.1"
     web3-utils "1.2.9"
+
+web3-eth-abi@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.7.4.tgz#3fee967bafd67f06b99ceaddc47ab0970f2a614a"
+  integrity sha512-eMZr8zgTbqyL9MCTCAvb67RbVyN5ZX7DvA0jbLOqRWCiw+KlJKTGnymKO6jPE8n5yjk4w01e165Qb11hTDwHgg==
+  dependencies:
+    "@ethersproject/abi" "^5.6.3"
+    web3-utils "1.7.4"
 
 web3-eth-accounts@1.2.9:
   version "1.2.9"
@@ -20828,6 +21161,23 @@ web3-eth-accounts@1.2.9:
     web3-core-method "1.2.9"
     web3-utils "1.2.9"
 
+web3-eth-accounts@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.7.4.tgz#7a24a4dfe947f7e9d1bae678529e591aa146167a"
+  integrity sha512-Y9vYLRKP7VU7Cgq6wG1jFaG2k3/eIuiTKAG8RAuQnb6Cd9k5BRqTm5uPIiSo0AP/u11jDomZ8j7+WEgkU9+Btw==
+  dependencies:
+    "@ethereumjs/common" "^2.5.0"
+    "@ethereumjs/tx" "^3.3.2"
+    crypto-browserify "3.12.0"
+    eth-lib "0.2.8"
+    ethereumjs-util "^7.0.10"
+    scrypt-js "^3.0.1"
+    uuid "3.3.2"
+    web3-core "1.7.4"
+    web3-core-helpers "1.7.4"
+    web3-core-method "1.7.4"
+    web3-utils "1.7.4"
+
 web3-eth-contract@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.2.9.tgz#713d9c6d502d8c8f22b696b7ffd8e254444e6bfd"
@@ -20842,6 +21192,20 @@ web3-eth-contract@1.2.9:
     web3-core-subscriptions "1.2.9"
     web3-eth-abi "1.2.9"
     web3-utils "1.2.9"
+
+web3-eth-contract@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.7.4.tgz#e5761cfb43d453f57be4777b2e5e7e1082078ff7"
+  integrity sha512-ZgSZMDVI1pE9uMQpK0T0HDT2oewHcfTCv0osEqf5qyn5KrcQDg1GT96/+S0dfqZ4HKj4lzS5O0rFyQiLPQ8LzQ==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    web3-core "1.7.4"
+    web3-core-helpers "1.7.4"
+    web3-core-method "1.7.4"
+    web3-core-promievent "1.7.4"
+    web3-core-subscriptions "1.7.4"
+    web3-eth-abi "1.7.4"
+    web3-utils "1.7.4"
 
 web3-eth-ens@1.2.9:
   version "1.2.9"
@@ -20858,6 +21222,20 @@ web3-eth-ens@1.2.9:
     web3-eth-contract "1.2.9"
     web3-utils "1.2.9"
 
+web3-eth-ens@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.7.4.tgz#346720305379c0a539e226141a9602f1da7bc0c8"
+  integrity sha512-Gw5CVU1+bFXP5RVXTCqJOmHn71X2ghNk9VcEH+9PchLr0PrKbHTA3hySpsPco1WJAyK4t8SNQVlNr3+bJ6/WZA==
+  dependencies:
+    content-hash "^2.5.2"
+    eth-ens-namehash "2.0.8"
+    web3-core "1.7.4"
+    web3-core-helpers "1.7.4"
+    web3-core-promievent "1.7.4"
+    web3-eth-abi "1.7.4"
+    web3-eth-contract "1.7.4"
+    web3-utils "1.7.4"
+
 web3-eth-iban@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.2.9.tgz#4ebf3d8783f34d04c4740dc18938556466399f7a"
@@ -20865,6 +21243,14 @@ web3-eth-iban@1.2.9:
   dependencies:
     bn.js "4.11.8"
     web3-utils "1.2.9"
+
+web3-eth-iban@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.7.4.tgz#711fb2547fdf0f988060027331b2b6c430505753"
+  integrity sha512-XyrsgWlZQMv5gRcjXMsNvAoCRvV5wN7YCfFV5+tHUCqN8g9T/o4XUS20vDWD0k4HNiAcWGFqT1nrls02MGZ08w==
+  dependencies:
+    bn.js "^5.2.1"
+    web3-utils "1.7.4"
 
 web3-eth-personal@1.2.9:
   version "1.2.9"
@@ -20877,6 +21263,18 @@ web3-eth-personal@1.2.9:
     web3-core-method "1.2.9"
     web3-net "1.2.9"
     web3-utils "1.2.9"
+
+web3-eth-personal@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.7.4.tgz#22c399794cb828a75703df8bb4b3c1331b471546"
+  integrity sha512-O10C1Hln5wvLQsDhlhmV58RhXo+GPZ5+W76frSsyIrkJWLtYQTCr5WxHtRC9sMD1idXLqODKKgI2DL+7xeZ0/g==
+  dependencies:
+    "@types/node" "^12.12.6"
+    web3-core "1.7.4"
+    web3-core-helpers "1.7.4"
+    web3-core-method "1.7.4"
+    web3-net "1.7.4"
+    web3-utils "1.7.4"
 
 web3-eth@1.2.9:
   version "1.2.9"
@@ -20897,6 +21295,24 @@ web3-eth@1.2.9:
     web3-net "1.2.9"
     web3-utils "1.2.9"
 
+web3-eth@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.7.4.tgz#a7c1d3ccdbba4de4a82df7e3c4db716e4a944bf2"
+  integrity sha512-JG0tTMv0Ijj039emXNHi07jLb0OiWSA9O24MRSk5vToTQyDNXihdF2oyq85LfHuF690lXZaAXrjhtLNlYqb7Ug==
+  dependencies:
+    web3-core "1.7.4"
+    web3-core-helpers "1.7.4"
+    web3-core-method "1.7.4"
+    web3-core-subscriptions "1.7.4"
+    web3-eth-abi "1.7.4"
+    web3-eth-accounts "1.7.4"
+    web3-eth-contract "1.7.4"
+    web3-eth-ens "1.7.4"
+    web3-eth-iban "1.7.4"
+    web3-eth-personal "1.7.4"
+    web3-net "1.7.4"
+    web3-utils "1.7.4"
+
 web3-net@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.2.9.tgz#51d248ed1bc5c37713c4ac40c0073d9beacd87d3"
@@ -20905,6 +21321,15 @@ web3-net@1.2.9:
     web3-core "1.2.9"
     web3-core-method "1.2.9"
     web3-utils "1.2.9"
+
+web3-net@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.7.4.tgz#3153dfd3423262dd6fbec7aae5467202c4cad431"
+  integrity sha512-d2Gj+DIARHvwIdmxFQ4PwAAXZVxYCR2lET0cxz4KXbE5Og3DNjJi+MoPkX+WqoUXqimu/EOd4Cd+7gefqVAFDg==
+  dependencies:
+    web3-core "1.7.4"
+    web3-core-method "1.7.4"
+    web3-utils "1.7.4"
 
 web3-provider-engine@15.0.7:
   version "15.0.7"
@@ -20942,6 +21367,14 @@ web3-providers-http@1.2.9:
     web3-core-helpers "1.2.9"
     xhr2-cookies "1.1.0"
 
+web3-providers-http@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.7.4.tgz#8209cdcb115db5ccae1f550d1c4e3005e7538d02"
+  integrity sha512-AU+/S+49rcogUER99TlhW+UBMk0N2DxvN54CJ2pK7alc2TQ7+cprNPLHJu4KREe8ndV0fT6JtWUfOMyTvl+FRA==
+  dependencies:
+    web3-core-helpers "1.7.4"
+    xhr2-cookies "1.1.0"
+
 web3-providers-ipc@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.2.9.tgz#6159eacfcd7ac31edc470d93ef10814fe874763b"
@@ -20950,6 +21383,14 @@ web3-providers-ipc@1.2.9:
     oboe "2.1.4"
     underscore "1.9.1"
     web3-core-helpers "1.2.9"
+
+web3-providers-ipc@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.7.4.tgz#02e85e99e48f432c9d34cee7d786c3685ec9fcfa"
+  integrity sha512-jhArOZ235dZy8fS8090t60nTxbd1ap92ibQw5xIrAQ9m7LcZKNfmLAQUVsD+3dTFvadRMi6z1vCO7zRi84gWHw==
+  dependencies:
+    oboe "2.1.5"
+    web3-core-helpers "1.7.4"
 
 web3-providers-ws@1.2.9:
   version "1.2.9"
@@ -20961,6 +21402,15 @@ web3-providers-ws@1.2.9:
     web3-core-helpers "1.2.9"
     websocket "^1.0.31"
 
+web3-providers-ws@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.7.4.tgz#6e60bcefb456f569a3e766e386d7807a96f90595"
+  integrity sha512-g72X77nrcHMFU8hRzQJzfgi/072n8dHwRCoTw+WQrGp+XCQ71fsk2qIu3Tp+nlp5BPn8bRudQbPblVm2uT4myQ==
+  dependencies:
+    eventemitter3 "4.0.4"
+    web3-core-helpers "1.7.4"
+    websocket "^1.0.32"
+
 web3-shh@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.2.9.tgz#c4ba70d6142cfd61341a50752d8cace9a0370911"
@@ -20970,6 +21420,16 @@ web3-shh@1.2.9:
     web3-core-method "1.2.9"
     web3-core-subscriptions "1.2.9"
     web3-net "1.2.9"
+
+web3-shh@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.7.4.tgz#bee91cce2737c529fd347274010b548b6ea060f1"
+  integrity sha512-mlSZxSYcMkuMCxqhTYnZkUdahZ11h+bBv/8TlkXp/IHpEe4/Gg+KAbmfudakq3EzG/04z70XQmPgWcUPrsEJ+A==
+  dependencies:
+    web3-core "1.7.4"
+    web3-core-method "1.7.4"
+    web3-core-subscriptions "1.7.4"
+    web3-net "1.7.4"
 
 web3-utils@1.2.9:
   version "1.2.9"
@@ -20985,6 +21445,19 @@ web3-utils@1.2.9:
     underscore "1.9.1"
     utf8 "3.0.0"
 
+web3-utils@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.7.4.tgz#eb6fa3706b058602747228234453811bbee017f5"
+  integrity sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==
+  dependencies:
+    bn.js "^5.2.1"
+    ethereum-bloom-filters "^1.0.6"
+    ethereumjs-util "^7.1.0"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randombytes "^2.1.0"
+    utf8 "3.0.0"
+
 web3@1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.2.9.tgz#cbcf1c0fba5e213a6dfb1f2c1f4b37062e4ce337"
@@ -20997,6 +21470,19 @@ web3@1.2.9:
     web3-net "1.2.9"
     web3-shh "1.2.9"
     web3-utils "1.2.9"
+
+web3@^1.5.0:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-1.7.4.tgz#00c9aef8e13ade92fd773d845fff250535828e93"
+  integrity sha512-iFGK5jO32vnXM/ASaJBaI0+gVR6uHozvYdxkdhaeOCD6HIQ4iIXadbO2atVpE9oc/H8l2MovJ4LtPhG7lIBN8A==
+  dependencies:
+    web3-bzz "1.7.4"
+    web3-core "1.7.4"
+    web3-eth "1.7.4"
+    web3-eth-personal "1.7.4"
+    web3-net "1.7.4"
+    web3-shh "1.7.4"
+    web3-utils "1.7.4"
 
 web3modal@1.9.0:
   version "1.9.0"
@@ -21197,7 +21683,7 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-websocket@^1.0.31:
+websocket@^1.0.31, websocket@^1.0.32:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
   integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
@@ -21281,6 +21767,18 @@ which-pm-runs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
+
+which-typed-array@^1.1.2:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.8.tgz#0cfd53401a6f334d90ed1125754a42ed663eb01f"
+  integrity sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.20.0"
+    for-each "^0.3.3"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.9"
 
 which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,10 +1272,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-0.0.14.tgz#03a04ae3b9dce130368bf9876e500a1a7a2c8e40"
-  integrity sha512-mNrKR0FIifrjpczNlpHXkbNY9reYrotZ+79j58nYk2Qr+CpsQiGv6vc9736uFTmWOCMFr8qGQae5eApJGotYmw==
+"@cowprotocol/cow-sdk@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-0.0.15.tgz#844d51e8ea4969521d72086c54d09394bbb0750b"
+  integrity sha512-Lz5iTGjzMNJ+gHERnm+71HKLwcBGh60w3OJU4LRiU0X6Ug1Rzlrgp+3Ok84zpi3LQgc79IvB5v5riI0J4goHkQ==
   dependencies:
     "@cowprotocol/contracts" "^1.3.1"
     ajv "^8.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,7 +1279,7 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^1.0.0":
+"@cowprotocol/cow-sdk@1.0.0-RC.0":
   version "1.0.0-RC.0"
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.0.tgz#acadbaf46f8538665a55d84daed8bf4976f33a94"
   integrity sha512-84GZNRFxl8ZJe6ZNGX6BlMj/UIZ9mwylaJv8HIJN3eEUnXGwZE48NElOQMINa4OaQv49cxh2C4K77E6HU9PiCQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,8 +1279,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@file:.yalc/@cowprotocol/cow-sdk":
-  version "1.0.0-RC.2"
+"@cowprotocol/cow-sdk@1.0.0-RC.3":
+  version "1.0.0-RC.3"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.3.tgz#b6bf78cbb6e66e95804679ab5b92f49da1a82d05"
+  integrity sha512-Jef69munoKMBmMOgZ+5P9oa6VzDHO61Bn61banmtPhVfaRwiC9GpkySFH9Q/5D2eBmQssP0cAmQSShe3nDchbw==
   dependencies:
     "@cowprotocol/app-data" "^0.0.1-RC.3"
     "@cowprotocol/contracts" "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,16 +1267,24 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cowprotocol/app-data@^0.0.1-RC.1":
+  version "0.0.1-RC.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.1-RC.2.tgz#0cde63b2efa9b36046c5c4c37e2ab72b9efe93d3"
+  integrity sha512-wA6DRCTStN+whPkawwRctAjUKlBXFrrAiysYIqsM02Vj0AuyhfygRBxRHG9g2vyssqR3dIYNQkJkserNyHX+pg==
+  dependencies:
+    ajv "^8.11.0"
+
 "@cowprotocol/contracts@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-0.0.15.tgz#844d51e8ea4969521d72086c54d09394bbb0750b"
-  integrity sha512-Lz5iTGjzMNJ+gHERnm+71HKLwcBGh60w3OJU4LRiU0X6Ug1Rzlrgp+3Ok84zpi3LQgc79IvB5v5riI0J4goHkQ==
+"@cowprotocol/cow-sdk@^1.0.0":
+  version "1.0.0-RC.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.0.tgz#acadbaf46f8538665a55d84daed8bf4976f33a94"
+  integrity sha512-84GZNRFxl8ZJe6ZNGX6BlMj/UIZ9mwylaJv8HIJN3eEUnXGwZE48NElOQMINa4OaQv49cxh2C4K77E6HU9PiCQ==
   dependencies:
+    "@cowprotocol/app-data" "^0.0.1-RC.1"
     "@cowprotocol/contracts" "^1.3.1"
     ajv "^8.8.2"
     cross-fetch "^3.1.5"
@@ -5332,7 +5340,7 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ajv@^8.8.2:
+ajv@^8.11.0, ajv@^8.8.2:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,17 +1279,15 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@1.0.0-RC.1":
-  version "1.0.0-RC.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.1.tgz#5762c1ca2ee4b1a024cc63483f1f752d750412c1"
-  integrity sha512-L7hQiOKY3KM79MbmYhipyvI513jaJLJJNGerUsprY7y0UvlVO5KI9/F0TsAZcjeCTX9le7lS1HsHWaqoVPpH9g==
+"@cowprotocol/cow-sdk@file:.yalc/@cowprotocol/cow-sdk":
+  version "1.0.0-RC.2"
   dependencies:
     "@cowprotocol/app-data" "^0.0.1-RC.3"
     "@cowprotocol/contracts" "^1.3.1"
     cross-fetch "^3.1.5"
     ethers "^5.5.3"
     graphql "^16.3.0"
-    graphql-request "^4.1.0"
+    graphql-request "^4.3.0"
     ipfs-only-hash "^4.0.0"
     loglevel "^1.8.0"
     multiformats "^9.6.4"
@@ -11371,10 +11369,10 @@ graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-graphql-request@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.2.0.tgz#063377bc2dd29cc46aed3fddcc65fe97b805ba81"
-  integrity sha512-uFeMyhhl8ss4LFgjlfPeAn2pqYw+CJto+cjj71uaBYIMMK2jPIqgHm5KEFxUk0YDD41A8Bq31a2b4G2WJBlp2Q==
+graphql-request@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.3.0.tgz#b934e08fcae764aa2cdc697d3c821f046cb5dbf2"
+  integrity sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==
   dependencies:
     cross-fetch "^3.1.5"
     extract-files "^9.0.0"


### PR DESCRIPTION
# Summary

Closes #136 

- [x] Add goerli network to **cow-sdk** instance constants (Update `cow-sdk` library)
- [x] Add the option in the **network-list** menu in the header UI
- [x] Create and verify new route prefix network `/goerli`
- [x] Enable/check routes for `/goerli` suffixes such as:
    - [x] `/search`, 
    - [x] `/address`, 
    - [x] `/orders`, 
    - [x] `/tx`
- [x] Fill in the home page data from the **goerli** network **subgraph**
