### PR TITLE
Show up to 2 decimals

### DIFF
--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -86,7 +86,7 @@ export function FilledProgress(props: Props): JSX.Element {
   const formattedMainAmount = formatSmartMaxPrecision(mainAmount, mainToken)
   const formattedSwappedAmount = formatSmartMaxPrecision(swappedAmount, swappedToken)
 
-  const formattedPercentage = filledPercentage.times('100').toString(10)
+  const formattedPercentage = filledPercentage.times('100').decimalPlaces(2).toString()
 
   return (
     <Wrapper>


### PR DESCRIPTION
# Summary

Closes #164 

Change base 10 string representation.

## To test
- Open [order](https://pr171--explorer.review.gnosisdev.com/orders/0x93299f3754e51938baae1946583382f9906092213cf8042b81eb877c8923fb67e63a13eedd01b624958acfe32145298788a7a7ba624ae706) and check "**Filled:**" field.
