### PR TITLE
Fix issue displaying the execution

### DIFF
--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -62,31 +62,47 @@ export function FilledProgress(props: Props): JSX.Element {
   let swappedAmount
   let action
 
+  let filledAmountWithFee, mainAmountWithFee, swappedAmountWithFee
   if (kind === 'sell') {
+    action = 'sold'
+
     mainToken = sellToken
     mainAddress = sellTokenAddress
     mainAmount = sellAmount.plus(feeAmount)
+
     swappedToken = buyToken
     swappedAddress = buyTokenAddress
     swappedAmount = executedBuyAmount
-    action = 'sold'
+
+    // Sell orders, add the fee in to the sellAmount (mainAmount, in this case)
+    mainAmountWithFee = mainAmount.plus(feeAmount)
+    filledAmountWithFee = filledAmount.plus(executedFeeAmount)
+    swappedAmountWithFee = swappedAmount
   } else {
+    action = 'bought'
+
     mainToken = buyToken
     mainAddress = buyTokenAddress
     mainAmount = buyAmount
+
     swappedToken = sellToken
     swappedAddress = sellTokenAddress
     swappedAmount = executedSellAmount
-    action = 'bought'
+
+    // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
+    mainAmountWithFee = mainAmount
+    filledAmountWithFee = filledAmount
+    swappedAmountWithFee = swappedAmount.plus(executedFeeAmount)
   }
 
   // In case the token object is empty, display the address
   const mainSymbol = mainToken ? safeTokenName(mainToken) : mainAddress
   const swappedSymbol = swappedToken ? safeTokenName(swappedToken) : swappedAddress
   // In case the token object is empty, display the raw amount (`decimals || 0` part)
-  const formattedFilledAmount = formatSmartMaxPrecision(filledAmount.plus(executedFeeAmount), mainToken)
-  const formattedMainAmount = formatSmartMaxPrecision(mainAmount, mainToken)
-  const formattedSwappedAmount = formatSmartMaxPrecision(swappedAmount, swappedToken)
+
+  const formattedMainAmount = formatSmartMaxPrecision(mainAmountWithFee, mainToken)
+  const formattedFilledAmount = formatSmartMaxPrecision(filledAmountWithFee, mainToken)
+  const formattedSwappedAmount = formatSmartMaxPrecision(swappedAmountWithFee, swappedToken)
 
   const formattedPercentage = filledPercentage.times('100').decimalPlaces(2).toString()
 
@@ -95,9 +111,11 @@ export function FilledProgress(props: Props): JSX.Element {
       <ProgressBar percentage={formattedPercentage} />
       <span>
         <b>
+          {/* Executed part (bought/sold tokens) */}
           {formattedFilledAmount} {mainSymbol}
         </b>{' '}
         {!fullyFilled && (
+          // Show the total amount to buy/sell. Only for orders that are not 100% executed
           <>
             of{' '}
             <b>
@@ -107,6 +125,9 @@ export function FilledProgress(props: Props): JSX.Element {
         )}
         {action}{' '}
         {touched && (
+          // Executed part of the trade:
+          //    Total buy tokens you receive (for sell orders)
+          //    Total sell tokens you pay (for buy orders)
           <>
             for a total of{' '}
             <b>


### PR DESCRIPTION
# Summary

Closes #183 


It tries to fix some issues with the Filled part of the order:
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/2352112/184420334-98766df8-f534-40cd-8c90-7f83d8136d76.png">

The fee should be taken into account, so it matches the TX the user observes in Etherscan. 

Now, I hope should work for:
- Buy orders or sell orders
- Partially executed or not

@alfetopito  Now im more convinced that its the right call to add the fee in the FILLED amount. The main reason, is to make it match what you observe in the Ethereum transaction. It's aligned with user expectations. But the other reason, and a subproduct of this PR, that now, you make it easy for the user to calculate the surplus! Now it's just deducting this two amounts (notice how it was not the case in production)

<img width="1333" alt="image" src="https://user-images.githubusercontent.com/2352112/184423401-965e3e3c-033e-4ea6-9642-e747b1061626.png">


# To Test
- Create sell/buy orders
- Partiall executed orders is harder to test

Some examples:
* Sell orders:
   * [Production](https://barn.explorer.cow.fi/rinkeby/orders/0x7c0c1186938ee24793f1788401f82eb37ab18546ba4b7b11e9546db515eaa070424a46612794dbb8000194937834250dc723ffa562c876ec) --> Notice how the amount of UNI is not 10, which is what the user transfered in the [TX](https://rinkeby.etherscan.io/tx/0x44f15cdfee343afe84f826a1288aa654dcb521e1bddedac8c791e757ff7f465f)
   *  [This PR](https://pr184--explorer.review.gnosisdev.com/rinkeby/orders/0x7c0c1186938ee24793f1788401f82eb37ab18546ba4b7b11e9546db515eaa070424a46612794dbb8000194937834250dc723ffa562c876ec) --> Sells 10 UNI
 * Buy Orders:
    * [Production](https://explorer.cow.fi/rinkeby/orders/0x84b1db5bf9ca32afe11fffa30a828f26c32d43572ce313b3b3e37c5c38527a9779063d9173c09887d536924e2f6eadbabac099f562f4e1e8) --> The buy amount is correct, but the sell says `0.010033647122025` when the [TX](https://rinkeby.etherscan.io/tx/0xe981bcb14f014532dd32ad3a4fd0ab11637f3a193bdde88775f1b5c66c7c145d) says `0.010287251434578686`
   *  [This PR](https://pr184--explorer.review.gnosisdev.com/rinkeby/orders/0x84b1db5bf9ca32afe11fffa30a828f26c32d43572ce313b3b3e37c5c38527a9779063d9173c09887d536924e2f6eadbabac099f562f4e1e8) --> Shows the cost of `0.010287251434578686` which matches the transaction
