### PR TITLE
183/fix filled amount issues 2

### DIFF
--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -83,13 +83,15 @@ const tooltip = {
   expiration:
     'The date and time at which an order will expire and effectively be cancelled. Depending on the type of order, it may have partial fills upon expiration.',
   type: 'An order can be either a Buy or Sell order. In addition, an order may be of type "Fill or Kill" (no partial fills) or a regular order (partial fills allowed).',
-  amount: 'The total sell and buy amount for this order.',
+  amount: 'The total sell and buy amount for this order. Sell amount includes the fee.',
   priceLimit:
-    'The limit price is the price at which this order shall be (partially) filled, in combination with the specified slippage.',
-  priceExecution: 'The actual price at which this order has been matched and executed.',
+    'The limit price is the price at which this order shall be (partially) filled, in combination with the specified slippage. The fee is already deduced from the sell amount',
+  priceExecution:
+    'The actual price at which this order has been matched and executed, after deducting the fees from the sold amount.',
   surplus:
     'The (averaged) surplus for this order. This is the positive difference between the initial limit price and the actual (average) execution price.',
-  filled: 'Indicates what percentage amount this order has been filled and the amount sold/bought.',
+  filled:
+    'Indicates what percentage amount this order has been filled and the amount sold/bought. Sold amount includes the fee.',
   fees: 'The amount of fees paid for this order. This will show a progressive number for orders with partial fills.',
 }
 

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -62,31 +62,47 @@ export function FilledProgress(props: Props): JSX.Element {
   let swappedAmount
   let action
 
+  let filledAmountWithFee, mainAmountWithFee, swappedAmountWithFee
   if (kind === 'sell') {
+    action = 'sold'
+
     mainToken = sellToken
     mainAddress = sellTokenAddress
     mainAmount = sellAmount.plus(feeAmount)
+
     swappedToken = buyToken
     swappedAddress = buyTokenAddress
     swappedAmount = executedBuyAmount
-    action = 'sold'
+
+    // Sell orders, add the fee in to the sellAmount (mainAmount, in this case)
+    mainAmountWithFee = mainAmount.plus(feeAmount)
+    filledAmountWithFee = filledAmount.plus(executedFeeAmount)
+    swappedAmountWithFee = swappedAmount
   } else {
+    action = 'bought'
+
     mainToken = buyToken
     mainAddress = buyTokenAddress
     mainAmount = buyAmount
+
     swappedToken = sellToken
     swappedAddress = sellTokenAddress
     swappedAmount = executedSellAmount
-    action = 'bought'
+
+    // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
+    mainAmountWithFee = mainAmount
+    filledAmountWithFee = filledAmount
+    swappedAmountWithFee = swappedAmount.plus(executedFeeAmount)
   }
 
   // In case the token object is empty, display the address
   const mainSymbol = mainToken ? safeTokenName(mainToken) : mainAddress
   const swappedSymbol = swappedToken ? safeTokenName(swappedToken) : swappedAddress
   // In case the token object is empty, display the raw amount (`decimals || 0` part)
-  const formattedFilledAmount = formatSmartMaxPrecision(filledAmount.plus(executedFeeAmount), mainToken)
-  const formattedMainAmount = formatSmartMaxPrecision(mainAmount, mainToken)
-  const formattedSwappedAmount = formatSmartMaxPrecision(swappedAmount, swappedToken)
+
+  const formattedMainAmount = formatSmartMaxPrecision(mainAmountWithFee, mainToken)
+  const formattedFilledAmount = formatSmartMaxPrecision(filledAmountWithFee, mainToken)
+  const formattedSwappedAmount = formatSmartMaxPrecision(swappedAmountWithFee, swappedToken)
 
   const formattedPercentage = filledPercentage.times('100').decimalPlaces(2).toString()
 
@@ -95,9 +111,11 @@ export function FilledProgress(props: Props): JSX.Element {
       <ProgressBar percentage={formattedPercentage} />
       <span>
         <b>
+          {/* Executed part (bought/sold tokens) */}
           {formattedFilledAmount} {mainSymbol}
         </b>{' '}
         {!fullyFilled && (
+          // Show the total amount to buy/sell. Only for orders that are not 100% executed
           <>
             of{' '}
             <b>
@@ -107,6 +125,9 @@ export function FilledProgress(props: Props): JSX.Element {
         )}
         {action}{' '}
         {touched && (
+          // Executed part of the trade:
+          //    Total buy tokens you receive (for sell orders)
+          //    Total sell tokens you pay (for buy orders)
           <>
             for a total of{' '}
             <b>

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -62,7 +62,7 @@ export function FilledProgress(props: Props): JSX.Element {
   let swappedAmount
   let action
 
-  let filledAmountWithFee, mainAmountWithFee, swappedAmountWithFee
+  let filledAmountWithFee, swappedAmountWithFee
   if (kind === 'sell') {
     action = 'sold'
 
@@ -75,7 +75,6 @@ export function FilledProgress(props: Props): JSX.Element {
     swappedAmount = executedBuyAmount
 
     // Sell orders, add the fee in to the sellAmount (mainAmount, in this case)
-    mainAmountWithFee = mainAmount.plus(feeAmount)
     filledAmountWithFee = filledAmount.plus(executedFeeAmount)
     swappedAmountWithFee = swappedAmount
   } else {
@@ -90,7 +89,6 @@ export function FilledProgress(props: Props): JSX.Element {
     swappedAmount = executedSellAmount
 
     // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
-    mainAmountWithFee = mainAmount
     filledAmountWithFee = filledAmount
     swappedAmountWithFee = swappedAmount.plus(executedFeeAmount)
   }
@@ -100,7 +98,7 @@ export function FilledProgress(props: Props): JSX.Element {
   const swappedSymbol = swappedToken ? safeTokenName(swappedToken) : swappedAddress
   // In case the token object is empty, display the raw amount (`decimals || 0` part)
 
-  const formattedMainAmount = formatSmartMaxPrecision(mainAmountWithFee, mainToken)
+  const formattedMainAmount = formatSmartMaxPrecision(mainAmount, mainToken)
   const formattedFilledAmount = formatSmartMaxPrecision(filledAmountWithFee, mainToken)
   const formattedSwappedAmount = formatSmartMaxPrecision(swappedAmountWithFee, swappedToken)
 


### PR DESCRIPTION
# Summary

Builds on top of/supersedes https://github.com/cowprotocol/explorer/pull/184

1. Fixed issue with double fee addition for partially fillable orders
2. Updated tooltips for `amount`, `limit price`, `execution price` and `filled` to account for fee inclusion/exclusion

# To Test

See testing steps on https://github.com/cowprotocol/explorer/pull/184

# Cases - left side PROD, right side these changes

## buy order, fill or kill
![Screen Shot 2022-08-19 at 11 21 59](https://user-images.githubusercontent.com/43217/185600106-63f69414-d42e-482c-9321-fe8506cedaf4.png)

## sell order, partially fillable
![Screen Shot 2022-08-19 at 11 07 01](https://user-images.githubusercontent.com/43217/185600109-e37c0862-ba9d-49fb-be45-95ad90b869d7.png)

## sell order, fill or kill
![Screen Shot 2022-08-19 at 11 06 42](https://user-images.githubusercontent.com/43217/185600111-2cc3a377-20d0-431b-b529-50503509bb93.png)
