### PR TITLE
[Top Tokens Table] Rename some columns

### DIFF
--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -418,11 +418,11 @@ const TokenTable: React.FC<Props> = (props) => {
           <th>Name</th>
           <th>Symbol</th>
           <th>Price</th>
-          <th>24h</th>
-          <th>7d</th>
-          <th>24h volume</th>
+          <th>Price (24h)</th>
+          <th>Price (7d)</th>
+          <th>Volume (24h)</th>
           <th>Total volume</th>
-          <th>Last 7 days</th>
+          <th>Price (last 7 days)</th>
         </tr>
       }
       body={tokenItems(tokens)}

--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -321,7 +321,7 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
         </HeaderValue>
       </td>
       <td>
-        <HeaderTitle>24h</HeaderTitle>
+        <HeaderTitle>Price (24h)</HeaderTitle>
         {handleLoadingState(
           lastDayPricePercentageDifference,
           <HeaderValue
@@ -332,7 +332,7 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
         )}
       </td>
       <td>
-        <HeaderTitle>7d</HeaderTitle>
+        <HeaderTitle>Price (7d)</HeaderTitle>
         {handleLoadingState(
           lastWeekPricePercentageDifference,
           <HeaderValue
@@ -345,7 +345,7 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
         )}
       </td>
       <td>
-        <HeaderTitle>24h volume</HeaderTitle>
+        <HeaderTitle>Volume (24h)</HeaderTitle>
         {handleLoadingState(
           lastDayUsdVolume,
           <HeaderValue>
@@ -376,7 +376,7 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
         </HeaderValue>
       </td>
       <td>
-        <HeaderTitle>Last 7 days</HeaderTitle>
+        <HeaderTitle>Price (last 7 days)</HeaderTitle>
         {handleLoadingState(lastWeekUsdPrices, <ChartWrapper ref={chartContainerRef} />)}
       </td>
     </tr>


### PR DESCRIPTION
# Summary

Closes #152 

Rename some columns in Top Tokens table

<img width="1170" alt="Screen Shot 2022-08-22 at 14 17 22" src="https://user-images.githubusercontent.com/11525018/185980805-0980e2a6-9601-4886-b4b6-50a09e117b7e.png">


# To Test

1. Open the `home` page.
* You'll notice some columns have been renamed in Top tokens table: 
     - 24h -> Price (24h)
     - 7d -> Price (7d)
     - 24h Volume -> Volume (24h)
     - Last 7 days -> Price (last 7 days)


