### PR TITLE
Fix User Orders on Explorer's Staging env not querying the production API endpoint

### DIFF
--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -2,7 +2,7 @@ import { GetTradesParams } from '@cowprotocol/cow-sdk'
 import { Network } from 'types'
 import { COW_SDK } from 'const'
 import { buildSearchString } from 'utils/url'
-import { isProd, isStaging } from 'utils/env'
+import { environmentName, Envs, isProd, isStaging } from 'utils/env'
 
 import {
   GetOrderParams,
@@ -14,6 +14,22 @@ import {
   WithNetworkId,
 } from './types'
 import { fetchQuery } from 'api/baseApi'
+
+// TODO: export this through the sdk
+export type ApiEnv = 'prod' | 'staging'
+
+function explorerToApiEnv(explorerEnv?: Envs): ApiEnv {
+  switch (explorerEnv) {
+    case 'production':
+    case 'staging':
+      return 'prod'
+    case 'development':
+    case 'barn':
+      return 'staging'
+    default:
+      return 'prod'
+  }
+}
 
 function getOperatorUrl(): Partial<Record<Network, string>> {
   if (isProd || isStaging) {
@@ -111,7 +127,7 @@ export async function getOrders(params: GetOrdersParams): Promise<RawOrder[]> {
 export async function getAccountOrders(params: GetAccountOrdersParams): Promise<RawOrder[]> {
   const { networkId, owner, offset, limit } = params
   // since we are not merging responses yet, we fix the sdk env to the current one
-  const env = isProd ? 'prod' : 'staging'
+  const env = explorerToApiEnv(environmentName)
   return COW_SDK.cowApi.getOrders({ owner, offset, limit }, { chainId: networkId, env })
 }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,4 +1,4 @@
-type Envs = {
+type EnvsFlags = {
   isDev: boolean
   isStaging: boolean
   isProd: boolean
@@ -7,7 +7,7 @@ type Envs = {
 
 const getRegex = (regex: string | undefined): RegExp | undefined => (regex ? new RegExp(regex) : undefined)
 
-function checkEnvironment(host: string): Envs {
+function checkEnvironment(host: string): EnvsFlags {
   const domainDevRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_DEV)
   const domainStagingRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_STAGING)
   const domainProdRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_PROD)
@@ -23,7 +23,9 @@ function checkEnvironment(host: string): Envs {
 
 const { isDev, isStaging, isProd, isBarn } = checkEnvironment(window.location.host)
 
-export const environmentName = (function (): 'production' | 'barn' | 'staging' | 'development' | undefined {
+export type Envs = 'production' | 'barn' | 'staging' | 'development'
+
+export const environmentName = (function (): Envs | undefined {
   if (isProd) {
     return 'production'
   } else if (isBarn) {


### PR DESCRIPTION
# Summary

Closes #200

Added a mapping between Explorer Envs -> API envs so its easier to reason about what to change and where to get it if we add new environments either way.

# To Test
The change needs to be deployed to staging to be validated

1. Go to https://protocol-explorer.staging.gnosisdev.com/
2. Inspect the API requests and verify they are against `https://api.cow.fi` and not `https://barn.api.cow.fi`

