### PR TITLE
[AppData] Store data when switching beetween tabs

### DIFF
--- a/src/apps/explorer/pages/AppData/DecodePage.tsx
+++ b/src/apps/explorer/pages/AppData/DecodePage.tsx
@@ -1,13 +1,40 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Form, { FormValidation } from '@rjsf/core'
 import { decodeAppDataSchema, FormProps, handleErrors, transformErrors } from './config'
 import DecodeAppData from 'components/AppData/DecodeAppData'
+import { TabData } from '.'
 
-const DecodePage: React.FC = () => {
-  const [formData, setFormdata] = useState<FormProps>()
-  const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
-  const [disabled, setDisabled] = useState<boolean>(true)
-  const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<boolean>(false)
+type DecodeProps = {
+  tabData: TabData
+  setTabData: React.Dispatch<React.SetStateAction<TabData>>
+}
+
+const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
+  const { decode } = tabData
+  const [formData, setFormdata] = useState<FormProps>(decode.formData)
+  const [isSubmitted, setIsSubmitted] = useState<boolean>(
+    decode.options.isSubmitted !== undefined ? decode.options.isSubmitted : false,
+  )
+  const [disabled, setDisabled] = useState<boolean>(
+    decode.options.disabled !== undefined ? decode.options.disabled : true,
+  )
+  const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<boolean>(
+    decode.options.invalidFormDataAttempted !== undefined ? decode.options.invalidFormDataAttempted : false,
+  )
+
+  useEffect(() => {
+    setTabData((prevState) => ({
+      ...prevState,
+      decode: {
+        formData,
+        options: {
+          isSubmitted,
+          disabled,
+          invalidFormDataAttempted,
+        },
+      },
+    }))
+  }, [disabled, formData, invalidFormDataAttempted, isSubmitted, setTabData])
 
   const formRef = React.useRef<Form<FormProps>>(null)
 

--- a/src/apps/explorer/pages/AppData/DecodePage.tsx
+++ b/src/apps/explorer/pages/AppData/DecodePage.tsx
@@ -12,14 +12,12 @@ type DecodeProps = {
 const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
   const { decode } = tabData
   const [formData, setFormdata] = useState<FormProps>(decode.formData)
-  const [isSubmitted, setIsSubmitted] = useState<boolean>(
-    decode.options.isSubmitted !== undefined ? decode.options.isSubmitted : false,
-  )
+  const [isSubmitted, setIsSubmitted] = useState<boolean>(decode.options.isSubmitted ?? false)
   const [disabled, setDisabled] = useState<boolean>(
     decode.options.disabled !== undefined ? decode.options.disabled : true,
   )
   const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<boolean>(
-    decode.options.invalidFormDataAttempted !== undefined ? decode.options.invalidFormDataAttempted : false,
+    decode.options.invalidFormDataAttempted ?? false,
   )
 
   useEffect(() => {

--- a/src/apps/explorer/pages/AppData/DecodePage.tsx
+++ b/src/apps/explorer/pages/AppData/DecodePage.tsx
@@ -13,9 +13,7 @@ const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
   const { decode } = tabData
   const [formData, setFormdata] = useState<FormProps>(decode.formData)
   const [isSubmitted, setIsSubmitted] = useState<boolean>(decode.options.isSubmitted ?? false)
-  const [disabled, setDisabled] = useState<boolean>(
-    decode.options.disabled !== undefined ? decode.options.disabled : true,
-  )
+  const [disabled, setDisabled] = useState<boolean>(decode.options.disabled ?? true)
   const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<boolean>(
     decode.options.invalidFormDataAttempted ?? false,
   )

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -33,12 +33,8 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
   const { encode } = tabData
   const [schema, setSchema] = useState<JSONSchema7>(encode.options.schema ?? {})
   const [appDataForm, setAppDataForm] = useState(encode.formData)
-  const [disabledAppData, setDisabledAppData] = useState<boolean>(
-    encode.options.disabledAppData !== undefined ? encode.options.disabledAppData : true,
-  )
-  const [disabledIPFS, setDisabledIPFS] = useState<boolean>(
-    encode.options.disabledIPFS !== undefined ? encode.options.disabledIPFS : true,
-  )
+  const [disabledAppData, setDisabledAppData] = useState<boolean>(encode.options.disabledAppData ?? true)
+  const [disabledIPFS, setDisabledIPFS] = useState<boolean>(encode.options.disabledIPFS ?? true)
   const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<{ appData: boolean; ipfs: boolean }>(
     encode.options.invalidFormDataAttempted ?? {
       appData: false,

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -7,6 +7,7 @@ import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import Spinner from 'components/common/Spinner'
 import AppDataWrapper from 'components/common/AppDataWrapper'
 import { Notification } from 'components/Notification'
+import { ExternalLink } from 'components/analytics/ExternalLink'
 import {
   INITIAL_FORM_VALUES,
   INVALID_IPFS_CREDENTIALS,
@@ -20,23 +21,41 @@ import {
   CustomField,
   FormProps,
 } from './config'
+import { TabData } from '.'
 import { IpfsWrapper } from './styled'
-import { ExternalLink } from 'components/analytics/ExternalLink'
 
-const EncodePage: React.FC = () => {
-  const [schema, setSchema] = useState<JSONSchema7>({})
-  const [appDataForm, setAppDataForm] = useState({})
-  const [disabledAppData, setDisabledAppData] = useState<boolean>(true)
-  const [disabledIPFS, setDisabledIPFS] = useState<boolean>(true)
-  const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<{ appData: boolean; ipfs: boolean }>({
-    appData: false,
-    ipfs: false,
-  })
-  const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [ipfsHashInfo, setIpfsHashInfo] = useState<IpfsHashInfo | void | undefined>()
-  const [ipfsCredentials, setIpfsCredentials] = useState<{ pinataApiKey?: string; pinataApiSecret?: string }>({})
-  const [isDocUploaded, setIsDocUploaded] = useState<boolean>(false)
-  const [error, setError] = useState<string>()
+type EncodeProps = {
+  tabData: TabData
+  setTabData: React.Dispatch<React.SetStateAction<TabData>>
+}
+
+const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
+  const { encode } = tabData
+  const [schema, setSchema] = useState<JSONSchema7>(encode.options.schema || {})
+  const [appDataForm, setAppDataForm] = useState(encode.formData)
+  const [disabledAppData, setDisabledAppData] = useState<boolean>(
+    encode.options.disabledAppData !== undefined ? encode.options.disabledAppData : true,
+  )
+  const [disabledIPFS, setDisabledIPFS] = useState<boolean>(
+    encode.options.disabledIPFS !== undefined ? encode.options.disabledIPFS : true,
+  )
+  const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<{ appData: boolean; ipfs: boolean }>(
+    encode.options.invalidFormDataAttempted || {
+      appData: false,
+      ipfs: false,
+    },
+  )
+  const [isLoading, setIsLoading] = useState<boolean>(
+    encode.options.isLoading !== undefined ? encode.options.isLoading : false,
+  )
+  const [ipfsHashInfo, setIpfsHashInfo] = useState<IpfsHashInfo | void | undefined>(encode.options.ipfsHashInfo)
+  const [ipfsCredentials, setIpfsCredentials] = useState<{ pinataApiKey?: string; pinataApiSecret?: string }>(
+    encode.options.ipfsCredentials || {},
+  )
+  const [isDocUploaded, setIsDocUploaded] = useState<boolean>(
+    encode.options.isDocUploaded !== undefined ? encode.options.isDocUploaded : false,
+  )
+  const [error, setError] = useState<string | undefined>(encode.options.error)
   const formRef = React.useRef<Form<FormProps>>(null)
   const ipfsFormRef = React.useRef<Form<FormProps>>(null)
 
@@ -47,8 +66,42 @@ const EncodePage: React.FC = () => {
       setAppDataForm(INITIAL_FORM_VALUES)
     }
 
-    fetchSchema()
-  }, [])
+    if (!Object.keys(schema).length) {
+      fetchSchema()
+    }
+  }, [schema])
+
+  useEffect(() => {
+    setTabData((prevState) => ({
+      ...prevState,
+      encode: {
+        formData: appDataForm,
+        options: {
+          schema,
+          disabledAppData,
+          disabledIPFS,
+          invalidFormDataAttempted,
+          isLoading,
+          ipfsHashInfo,
+          ipfsCredentials,
+          isDocUploaded,
+          error,
+        },
+      },
+    }))
+  }, [
+    appDataForm,
+    disabledAppData,
+    disabledIPFS,
+    error,
+    invalidFormDataAttempted,
+    ipfsCredentials,
+    ipfsHashInfo,
+    isDocUploaded,
+    isLoading,
+    schema,
+    setTabData,
+  ])
 
   const toggleInvalid = (data: { [key: string]: boolean }): void => {
     setInvalidFormDataAttempted((prevState) => ({ ...prevState, ...data }))

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -262,6 +262,9 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
                 schema={ipfsSchema}
                 uiSchema={ipfsUiSchema}
               >
+                <span className="disclaimer">
+                  IPFS credentials are saved in memory for the current page and will be cleaned-up afterwards.
+                </span>
                 <button className="btn btn-info" disabled={disabledIPFS} type="submit">
                   UPLOAD APPDATA TO IPFS
                 </button>

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -31,7 +31,7 @@ type EncodeProps = {
 
 const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
   const { encode } = tabData
-  const [schema, setSchema] = useState<JSONSchema7>(encode.options.schema || {})
+  const [schema, setSchema] = useState<JSONSchema7>(encode.options.schema ?? {})
   const [appDataForm, setAppDataForm] = useState(encode.formData)
   const [disabledAppData, setDisabledAppData] = useState<boolean>(
     encode.options.disabledAppData !== undefined ? encode.options.disabledAppData : true,
@@ -40,21 +40,17 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
     encode.options.disabledIPFS !== undefined ? encode.options.disabledIPFS : true,
   )
   const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<{ appData: boolean; ipfs: boolean }>(
-    encode.options.invalidFormDataAttempted || {
+    encode.options.invalidFormDataAttempted ?? {
       appData: false,
       ipfs: false,
     },
   )
-  const [isLoading, setIsLoading] = useState<boolean>(
-    encode.options.isLoading !== undefined ? encode.options.isLoading : false,
-  )
+  const [isLoading, setIsLoading] = useState<boolean>(encode.options.isLoading ?? false)
   const [ipfsHashInfo, setIpfsHashInfo] = useState<IpfsHashInfo | void | undefined>(encode.options.ipfsHashInfo)
   const [ipfsCredentials, setIpfsCredentials] = useState<{ pinataApiKey?: string; pinataApiSecret?: string }>(
-    encode.options.ipfsCredentials || {},
+    encode.options.ipfsCredentials ?? {},
   )
-  const [isDocUploaded, setIsDocUploaded] = useState<boolean>(
-    encode.options.isDocUploaded !== undefined ? encode.options.isDocUploaded : false,
-  )
+  const [isDocUploaded, setIsDocUploaded] = useState<boolean>(encode.options.isDocUploaded ?? false)
   const [error, setError] = useState<string | undefined>(encode.options.error)
   const formRef = React.useRef<Form<FormProps>>(null)
   const ipfsFormRef = React.useRef<Form<FormProps>>(null)
@@ -120,8 +116,6 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
   const handleOnChange = useCallback(
     ({ formData }: FormProps): void => {
       const resetFormFields = (form: string): void => {
-        setDisabledIPFS(true)
-        setIpfsCredentials({})
         toggleInvalid({ ipfs: false })
         if (form === 'appData') {
           setDisabledAppData(true)

--- a/src/apps/explorer/pages/AppData/index.tsx
+++ b/src/apps/explorer/pages/AppData/index.tsx
@@ -8,11 +8,18 @@ import TabIcon from 'components/common/Tabs/TabIcon'
 import { TabItemInterface } from 'components/common/Tabs/Tabs'
 
 import { ContentCard as Content, Title } from 'apps/explorer/pages/styled'
+import { FormProps } from './config'
+
 import { StyledExplorerTabs, Wrapper } from './styled'
 
 enum TabView {
   ENCODE = 1,
   DECODE,
+}
+
+export type TabData = {
+  encode: { formData: FormProps; options: any }
+  decode: { formData: FormProps; options: any }
 }
 
 const DEFAULT_TAB = TabView[1]
@@ -22,17 +29,17 @@ function useQueryViewParams(): { tab: string } {
   return { tab: query.get('tab')?.toUpperCase() || DEFAULT_TAB } // if URL param empty will be used DEFAULT
 }
 
-const tabItems = (): TabItemInterface[] => {
+const tabItems = (tabData: TabData, setTabData: React.Dispatch<React.SetStateAction<TabData>>): TabItemInterface[] => {
   return [
     {
       id: TabView.ENCODE,
       tab: <TabIcon title="Encode" iconFontName={faListUl} />,
-      content: <EncodePage />,
+      content: <EncodePage tabData={tabData} setTabData={setTabData} />,
     },
     {
       id: TabView.DECODE,
       tab: <TabIcon title="Decode" iconFontName={faCode} />,
-      content: <DecodePage />,
+      content: <DecodePage tabData={tabData} setTabData={setTabData} />,
     },
   ]
 }
@@ -40,6 +47,10 @@ const tabItems = (): TabItemInterface[] => {
 const AppDataPage: React.FC = () => {
   const history = useHistory()
   const { tab } = useQueryViewParams()
+  const [tabData, setTabData] = useState<TabData>({
+    encode: { formData: {}, options: {} },
+    decode: { formData: {}, options: {} },
+  })
   const [tabViewSelected, setTabViewSelected] = useState<TabView>(TabView[tab] || TabView[DEFAULT_TAB]) // use DEFAULT when URL param is outside the enum
 
   const onChangeTab = useCallback((tabId: number) => {
@@ -59,7 +70,7 @@ const AppDataPage: React.FC = () => {
       <Content>
         <StyledExplorerTabs
           className={`appData-tab--${TabView[tabViewSelected].toLowerCase()}`}
-          tabItems={tabItems()}
+          tabItems={tabItems(tabData, setTabData)}
           defaultTab={tabViewSelected}
           onChange={(key: number): void => onChangeTab(key)}
         />

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -128,6 +128,10 @@ export const Wrapper = styled(WrapperTemplate)`
     p {
       padding-right: 0;
     }
+    .disclaimer {
+      font-size: 1.2rem;
+      line-height: 1.3;
+    }
   }
   button {
     &:disabled {


### PR DESCRIPTION
# Summary

Closes #177 

Store appData info when switching between encode/decode tabs.

https://user-images.githubusercontent.com/11525018/186576004-38fb94d3-e405-4a87-895c-16d161c424bf.mov

# To Test

1. Open the page `appdata`.
2. Complete some data in one of  tabs and switch to the other or viceversa 
     * You'll see the data in persisted. 

**Disclaimer: This will only work as long as you keep in the appData page. If you go to another page and then you want to go back, data will be deleted.**

