### PR TITLE
[App Data] Remove default version values + read only fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.9.12",
     "@apollo/client": "^3.1.5",
+    "@cowprotocol/app-data": "0.0.1-RC.5",
     "@cowprotocol/contracts": "1.3.1",
     "@cowprotocol/cow-sdk": "1.0.0-RC.5",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/src/apps/explorer/pages/AppData/config.tsx
+++ b/src/apps/explorer/pages/AppData/config.tsx
@@ -1,11 +1,6 @@
 import React, { RefObject } from 'react'
 import Form, { AjvError, FieldProps, FormValidation } from '@rjsf/core'
-import {
-  LATEST_APP_DATA_VERSION,
-  LATEST_QUOTE_METADATA_VERSION,
-  LATEST_REFERRER_METADATA_VERSION,
-  getAppDataSchema,
-} from '@cowprotocol/app-data'
+import { LATEST_APP_DATA_VERSION, getAppDataSchema } from '@cowprotocol/app-data'
 import { JSONSchema7 } from 'json-schema'
 import { HelpTooltip } from 'components/Tooltip'
 
@@ -28,12 +23,6 @@ export const INVALID_IPFS_CREDENTIALS = [
 
 export type FormProps = Record<string, any>
 
-const APP_VERSION = {
-  appData: LATEST_APP_DATA_VERSION,
-  quote: LATEST_QUOTE_METADATA_VERSION,
-  referrer: LATEST_REFERRER_METADATA_VERSION,
-}
-
 export const getSchema = async (): Promise<JSONSchema7> => {
   const latestSchema = (await getAppDataSchema(LATEST_APP_DATA_VERSION)).default as JSONSchema7
   deleteAllPropertiesByName(latestSchema, 'examples')
@@ -45,9 +34,6 @@ const setDependencies = (formattedSchema: JSONSchema7, field: string, dependenci
   if (formattedSchema?.properties?.metadata['properties'][field]) {
     const requiredFields = formattedSchema.properties.metadata['properties'][field].required
     deletePropertyPath(formattedSchema, `properties.metadata.properties.${field}.required`)
-
-    formattedSchema.properties.metadata['properties'][field].properties.version['readOnly'] = true
-    formattedSchema.properties.metadata['properties'][field].properties.version['default'] = APP_VERSION[field]
 
     const properties = formattedSchema.properties.metadata['properties'][field].properties
     const [fieldKey] = Object.keys(dependencies)
@@ -67,11 +53,6 @@ const setDependencies = (formattedSchema: JSONSchema7, field: string, dependenci
 
 const formatSchema = (schema: JSONSchema7): JSONSchema7 => {
   const formattedSchema = structuredClone(schema)
-
-  if (formattedSchema?.properties?.version) {
-    formattedSchema.properties.version['readOnly'] = true
-    formattedSchema.properties.version['default'] = LATEST_APP_DATA_VERSION
-  }
 
   setDependencies(formattedSchema, 'quote', quoteDependencies)
   setDependencies(formattedSchema, 'referrer', referrerDependencies)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,6 +1267,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cowprotocol/app-data@0.0.1-RC.5":
+  version "0.0.1-RC.5"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.1-RC.5.tgz#9ad8c3e45865cc6e1b7e68f7e4f967b0a432af4a"
+  integrity sha512-cMzXAWt9pLoXaJRExcQHW6QN/ls4sNCrqCHAmi6TCVKaLfHelvjSmyHTEqE0OBwXrCuOeuIzE0jhiEJ7U6qEpg==
+  dependencies:
+    ajv "^8.11.0"
+
 "@cowprotocol/app-data@^0.0.1-RC.3":
   version "0.0.1-RC.3"
   resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.1-RC.3.tgz#929341c4a74dedff86dc416be1be3d3e5d29d26e"
@@ -2210,12 +2217,10 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.1.2"
 
-
 "@fortawesome/free-regular-svg-icons@^6.1.2":
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.2.tgz#9f04009098addcc11d0d185126f058ed042c3099"
   integrity sha512-xR4hA+tAwsaTHGfb+25H1gVU/aJ0Rzu+xIUfnyrhaL13yNQ7TWiI2RvzniAaB+VGHDU2a+Pk96Ve+pkN3/+TTQ==
-
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.1.2"
 


### PR DESCRIPTION
# Summary

This PR bumped `@cowprotocol/app-data` version to `0.0.1-RC.5` so that we can remove logic for setting default version values.

# To Test

1. Open the `appData` page.
   * You will see version field is set to default and read only.
2.  Check Referrer and Quote fields
    * You'll see version fields for both properties are set to default and read only as well.




