### PR TITLE
[App Data] Add more context

### DIFF
--- a/src/apps/explorer/pages/AppData/DecodePage.tsx
+++ b/src/apps/explorer/pages/AppData/DecodePage.tsx
@@ -52,42 +52,44 @@ const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
   const onError = (_: FormProps, errors: FormValidation): FormValidation => handleErrors(formRef, errors, setDisabled)
 
   return (
-    <div className="decode-container">
-      <div className="left-panel">
-        <div className="info-header box">
-          <p>
-            The decode tool allows you to decode an <strong>appData</strong> hash into the corresponding stored JSON
-            document, if any.
-          </p>
-          <p>
-            <strong>Note:</strong> Not all hexes correspond to an IPFS file and even so it doesn’t guarantee that the
-            file is following our defined JSON schema.
-          </p>
-        </div>
-        <Form
-          className="data-form"
-          showErrorList={false}
-          onChange={handleOnChange}
-          formData={formData}
-          ref={formRef}
-          onSubmit={onSubmit}
-          transformErrors={transformErrors}
-          liveValidate={invalidFormDataAttempted}
-          noHtml5Validate
-          validate={onError}
-          onError={(): void => setInvalidFormDataAttempted(true)}
-          schema={decodeAppDataSchema}
-        >
-          <button className="btn btn-info" disabled={disabled} type="submit">
-            DECODE APPDATA
-          </button>
-        </Form>
+    <div>
+      <div className="info-header box">
+        <p>
+          The decode tool allows you to decode an <strong>appData</strong> hash into the corresponding stored JSON
+          document, if any.
+        </p>
+        <p>
+          <strong>Note:</strong> Not all hexes correspond to an IPFS file and even so it doesn’t guarantee that the file
+          is following our defined JSON schema.
+        </p>
       </div>
-      {isSubmitted && (
-        <div className="decode-section">
-          <DecodeAppData showExpanded appData={formData?.appData} />
+      <div className="decode-container">
+        <div className="left-panel">
+          <Form
+            className="data-form"
+            showErrorList={false}
+            onChange={handleOnChange}
+            formData={formData}
+            ref={formRef}
+            onSubmit={onSubmit}
+            transformErrors={transformErrors}
+            liveValidate={invalidFormDataAttempted}
+            noHtml5Validate
+            validate={onError}
+            onError={(): void => setInvalidFormDataAttempted(true)}
+            schema={decodeAppDataSchema}
+          >
+            <button className="btn btn-info" disabled={disabled} type="submit">
+              DECODE APPDATA
+            </button>
+          </Form>
         </div>
-      )}
+        {isSubmitted && (
+          <div className="decode-section">
+            <DecodeAppData showExpanded appData={formData?.appData} />
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/apps/explorer/pages/AppData/DecodePage.tsx
+++ b/src/apps/explorer/pages/AppData/DecodePage.tsx
@@ -53,24 +53,32 @@ const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
 
   return (
     <div className="decode-container">
-      <Form
-        className="data-form"
-        showErrorList={false}
-        onChange={handleOnChange}
-        formData={formData}
-        ref={formRef}
-        onSubmit={onSubmit}
-        transformErrors={transformErrors}
-        liveValidate={invalidFormDataAttempted}
-        noHtml5Validate
-        validate={onError}
-        onError={(): void => setInvalidFormDataAttempted(true)}
-        schema={decodeAppDataSchema}
-      >
-        <button className="btn btn-info" disabled={disabled} type="submit">
-          DECODE APPDATA
-        </button>
-      </Form>
+      <div className="left-panel">
+        <div className="info-header">
+          <p>
+            The digest hash is what is used as <strong>appData</strong> and should be included in your orders to track
+            your created <strong>appCode</strong>.
+          </p>
+        </div>
+        <Form
+          className="data-form"
+          showErrorList={false}
+          onChange={handleOnChange}
+          formData={formData}
+          ref={formRef}
+          onSubmit={onSubmit}
+          transformErrors={transformErrors}
+          liveValidate={invalidFormDataAttempted}
+          noHtml5Validate
+          validate={onError}
+          onError={(): void => setInvalidFormDataAttempted(true)}
+          schema={decodeAppDataSchema}
+        >
+          <button className="btn btn-info" disabled={disabled} type="submit">
+            DECODE APPDATA
+          </button>
+        </Form>
+      </div>
       {isSubmitted && <DecodeAppData showExpanded appData={formData?.appData} />}
     </div>
   )

--- a/src/apps/explorer/pages/AppData/DecodePage.tsx
+++ b/src/apps/explorer/pages/AppData/DecodePage.tsx
@@ -52,7 +52,7 @@ const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
   const onError = (_: FormProps, errors: FormValidation): FormValidation => handleErrors(formRef, errors, setDisabled)
 
   return (
-    <div>
+    <div className="main-container">
       <div className="info-header box">
         <p>
           The decode tool allows you to decode an <strong>appData</strong> hash into the corresponding stored JSON

--- a/src/apps/explorer/pages/AppData/DecodePage.tsx
+++ b/src/apps/explorer/pages/AppData/DecodePage.tsx
@@ -54,10 +54,14 @@ const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
   return (
     <div className="decode-container">
       <div className="left-panel">
-        <div className="info-header">
+        <div className="info-header box">
           <p>
-            The digest hash is what is used as <strong>appData</strong> and should be included in your orders to track
-            your created <strong>appCode</strong>.
+            The decode tool allows you to decode an <strong>appData</strong> hash into the corresponding stored JSON
+            document, if any.
+          </p>
+          <p>
+            <strong>Note:</strong> Not all hexes correspond to an IPFS file and even so it doesn’t guarantee that the
+            file is following our defined JSON schema.
           </p>
         </div>
         <Form

--- a/src/apps/explorer/pages/AppData/DecodePage.tsx
+++ b/src/apps/explorer/pages/AppData/DecodePage.tsx
@@ -83,7 +83,11 @@ const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
           </button>
         </Form>
       </div>
-      {isSubmitted && <DecodeAppData showExpanded appData={formData?.appData} />}
+      {isSubmitted && (
+        <div className="decode-section">
+          <DecodeAppData showExpanded appData={formData?.appData} />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -7,7 +7,6 @@ import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import Spinner from 'components/common/Spinner'
 import AppDataWrapper from 'components/common/AppDataWrapper'
 import { Notification } from 'components/Notification'
-import { ExternalLink } from 'components/analytics/ExternalLink'
 import {
   INITIAL_FORM_VALUES,
   INVALID_IPFS_CREDENTIALS,
@@ -225,24 +224,6 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData, handleTabChang
             <p>
               This is the generated and <strong>prettified</strong> file based on the input you provided on the form.
             </p>
-            <p>AppData Root Schema information can be found in:</p>
-            <ExternalLink
-              target={'_blank'}
-              rel="noopener noreferrer"
-              href={`https://docs.cow.fi/front-end/creating-app-ids`}
-            >
-              {' '}
-              AppData documentation
-            </ExternalLink>{' '}
-            |
-            <ExternalLink
-              target={'_blank'}
-              rel="noopener noreferrer"
-              href={`https://docs.cow.fi/front-end/creating-app-ids/create-the-order-meta-data-file/metadata`}
-            >
-              {' '}
-              Metadata documentation
-            </ExternalLink>
             <RowWithCopyButton
               textToCopy={JSON.stringify(handleFormatData(appDataForm), null, 2)}
               contentsToDisplay={
@@ -286,9 +267,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData, handleTabChang
                 </p>
                 <p>
                   Once uploaded, you can use the <strong>appData</strong> hash in the
-                  <a href="" onClick={(): void => handleTabChange(TabView.DECODE)}>
-                    Decode
-                  </a>
+                  <a onClick={(): void => handleTabChange(TabView.DECODE)}>Decode</a>
                   tab to verify it.
                 </p>
               </div>

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -175,6 +175,14 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
 
   return (
     <>
+      <div className="info-header">
+        <p>The metadata document is a JSON file that follows a specific format.</p>
+        <p>Each metadata will contain version as a mandatory field.</p>
+        <p>
+          The schema is defined using a <a href="https://json-schema.org">https://json-schema.org</a> schema
+          specification.
+        </p>
+      </div>
       <div className="form-container">
         <Form
           className="data-form"
@@ -242,6 +250,13 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
         {ipfsHashInfo && (
           <>
             <IpfsWrapper>
+              <div className="info-header inner-form">
+                <p>If you upload the file directly, the resulting hash/appDataHash might differ.</p>
+                <p>
+                  The hash/IPFS CID calculated by the tool is a stringified file without a new line at the end. That
+                  means that you will get different results if the file is uploaded directly as a file.
+                </p>
+              </div>
               <Form
                 className="data-form"
                 showErrorList={false}

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -242,7 +242,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData, handleTabChang
                   textToCopy={ipfsHashInfo.appDataHash}
                   contentsToDisplay={ipfsHashInfo.appDataHash}
                 />
-                <p>Note: Don’t forget to upload this file to IPFS!</p>
+                <p className="disclaimer">Note: Don’t forget to upload this file to IPFS!</p>
               </>
             )}
           </div>

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -21,15 +21,16 @@ import {
   CustomField,
   FormProps,
 } from './config'
-import { TabData } from '.'
+import { TabData, TabView } from '.'
 import { IpfsWrapper } from './styled'
 
 type EncodeProps = {
   tabData: TabData
   setTabData: React.Dispatch<React.SetStateAction<TabData>>
+  handleTabChange: (tabId: number) => void
 }
 
-const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
+const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData, handleTabChange }) => {
   const { encode } = tabData
   const [schema, setSchema] = useState<JSONSchema7>(encode.options.schema ?? {})
   const [appDataForm, setAppDataForm] = useState(encode.formData)
@@ -175,12 +176,24 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
 
   return (
     <>
-      <div className="info-header">
-        <p>The metadata document is a JSON file that follows a specific format.</p>
-        <p>Each metadata will contain version as a mandatory field.</p>
+      <div className="info-header box">
         <p>
-          The schema is defined using a <a href="https://json-schema.org">https://json-schema.org</a> schema
-          specification.
+          The <strong>appData</strong> optional field part of CoW Protocol orders is the hex digest of an IPFS
+          document’s CID of a JSON file.
+        </p>
+        <p>
+          The JSON file follows a
+          <a target="_blank" href="https://json-schema.org" rel="noreferrer">
+            JSON schema
+          </a>
+          defined on app-data
+          <a target="_blank" href="https://github.com/cowprotocol/app-data" rel="noreferrer">
+            repo.
+          </a>
+        </p>
+        <p>
+          This page offers an easy way to create such JSON with the most up to date version and offers a way to upload
+          it to IPFS.
         </p>
       </div>
       <div className="form-container">
@@ -209,6 +222,9 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
         </Form>
         <AppDataWrapper>
           <div className="hidden-content">
+            <p>
+              This is the generated and <strong>prettified</strong> file based on the input you provided on the form.
+            </p>
             <p>AppData Root Schema information can be found in:</p>
             <ExternalLink
               target={'_blank'}
@@ -236,11 +252,16 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
             {ipfsHashInfo && (
               <>
                 <h4>AppData Hash</h4>
+                <p>
+                  This is the corresponding hash of the above document. Use this in your orders <strong>appData</strong>{' '}
+                  field.
+                </p>
                 <RowWithCopyButton
                   className="appData-hash"
                   textToCopy={ipfsHashInfo.appDataHash}
                   contentsToDisplay={ipfsHashInfo.appDataHash}
                 />
+                <p>Note: Don’t forget to upload this file to IPFS!</p>
               </>
             )}
           </div>
@@ -251,10 +272,24 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
           <>
             <IpfsWrapper>
               <div className="info-header inner-form">
-                <p>If you upload the file directly, the resulting hash/appDataHash might differ.</p>
+                <h2>IPFS UPLOAD</h2>
                 <p>
-                  The hash/IPFS CID calculated by the tool is a stringified file without a new line at the end. That
-                  means that you will get different results if the file is uploaded directly as a file.
+                  We offer an integrated way to upload the generated file to IPFS directly through
+                  <a target="_blank" href="https://docs.pinata.cloud/pinata-api" rel="noreferrer">
+                    Pinata’s
+                  </a>
+                  API.
+                </p>
+                <p>
+                  Insert your credentials and hit upload. The resulting <strong>appData</strong> hash is displayed on
+                  the generated section.
+                </p>
+                <p>
+                  Once uploaded, you can use the <strong>appData</strong> hash in the
+                  <a href="" onClick={(): void => handleTabChange(TabView.DECODE)}>
+                    Decode
+                  </a>
+                  tab to verify it.
                 </p>
               </div>
               <Form
@@ -274,7 +309,13 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData }) => {
                 uiSchema={ipfsUiSchema}
               >
                 <span className="disclaimer">
-                  IPFS credentials are saved in memory for the current page and will be cleaned-up afterwards.
+                  <strong>Note:</strong> The credentials are kept in memory only while you are at this page. When you
+                  navigate away or close the browser tab it’ll be cleared.
+                </span>
+                <span className="disclaimer">
+                  <strong>Note:</strong> If you upload the file directly, the resulting hash/appDataHash might differ.
+                  The hash/IPFS CID calculated by the tool is a minified and stringified file without a new line at the
+                  end. That means that you will get different results if the file is uploaded directly as a file.
                 </span>
                 <button className="btn btn-info" disabled={disabledIPFS} type="submit">
                   UPLOAD APPDATA TO IPFS

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -309,13 +309,18 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData, handleTabChang
                 uiSchema={ipfsUiSchema}
               >
                 <span className="disclaimer">
-                  <strong>Note:</strong> The credentials are kept in memory only while you are at this page. When you
-                  navigate away or close the browser tab it’ll be cleared.
-                </span>
-                <span className="disclaimer">
-                  <strong>Note:</strong> If you upload the file directly, the resulting hash/appDataHash might differ.
-                  The hash/IPFS CID calculated by the tool is a minified and stringified file without a new line at the
-                  end. That means that you will get different results if the file is uploaded directly as a file.
+                  <strong>Notes:</strong>
+                  <ol>
+                    <li>
+                      The credentials are kept in memory only while you are at this page. When you navigate away or
+                      close the browser tab it’ll be cleared.
+                    </li>
+                    <li>
+                      If you upload the file directly, the resulting hash/appDataHash might differ. The hash/IPFS CID
+                      calculated by the tool is a minified and stringified file without a new line at the end. That
+                      means that you will get different results if the file is uploaded directly as a file.
+                    </li>
+                  </ol>
                 </span>
                 <button className="btn btn-info" disabled={disabledIPFS} type="submit">
                   UPLOAD APPDATA TO IPFS

--- a/src/apps/explorer/pages/AppData/config.tsx
+++ b/src/apps/explorer/pages/AppData/config.tsx
@@ -197,7 +197,6 @@ export const decodeAppDataSchema: JSONSchema7 = {
     appData: {
       type: 'string',
       title: 'AppData',
-      description: 'Add your AppData hash.',
       pattern: '^0x[a-fA-F0-9]{64}',
     },
   },

--- a/src/apps/explorer/pages/AppData/index.tsx
+++ b/src/apps/explorer/pages/AppData/index.tsx
@@ -12,9 +12,9 @@ import { FormProps } from './config'
 
 import { StyledExplorerTabs, Wrapper } from './styled'
 
-enum TabView {
+export enum TabView {
   ENCODE = 1,
-  DECODE,
+  DECODE = 2,
 }
 
 export type TabData = {
@@ -29,12 +29,16 @@ function useQueryViewParams(): { tab: string } {
   return { tab: query.get('tab')?.toUpperCase() || DEFAULT_TAB } // if URL param empty will be used DEFAULT
 }
 
-const tabItems = (tabData: TabData, setTabData: React.Dispatch<React.SetStateAction<TabData>>): TabItemInterface[] => {
+const tabItems = (
+  tabData: TabData,
+  setTabData: React.Dispatch<React.SetStateAction<TabData>>,
+  onChangeTab: (tabId: number) => void,
+): TabItemInterface[] => {
   return [
     {
       id: TabView.ENCODE,
       tab: <TabIcon title="Encode" iconFontName={faListUl} />,
-      content: <EncodePage tabData={tabData} setTabData={setTabData} />,
+      content: <EncodePage tabData={tabData} setTabData={setTabData} handleTabChange={onChangeTab} />,
     },
     {
       id: TabView.DECODE,
@@ -56,7 +60,6 @@ const AppDataPage: React.FC = () => {
   const onChangeTab = useCallback((tabId: number) => {
     const newTabViewName = TabView[tabId]
     if (!newTabViewName) return
-
     setTabViewSelected(TabView[newTabViewName])
   }, [])
 
@@ -70,7 +73,7 @@ const AppDataPage: React.FC = () => {
       <Content>
         <StyledExplorerTabs
           className={`appData-tab--${TabView[tabViewSelected].toLowerCase()}`}
-          tabItems={tabItems(tabData, setTabData)}
+          tabItems={tabItems(tabData, setTabData, onChangeTab)}
           defaultTab={tabViewSelected}
           onChange={(key: number): void => onChangeTab(key)}
         />

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -139,10 +139,10 @@ export const Wrapper = styled(WrapperTemplate)`
   }
   .decode-container {
     display: flex;
-    justify-content: space-between;
+    gap: 10rem;
     flex: 1;
     div {
-      align-items: flex-start !important;
+      align-items: center;
     }
     .left-pannel {
       display: flex;
@@ -152,6 +152,7 @@ export const Wrapper = styled(WrapperTemplate)`
     ${media.mobile} {
       margin: 2rem 0;
       flex-direction: column;
+      gap: 5rem;
     }
     ${media.mediumDown} {
       margin: 2rem 0;

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -42,6 +42,7 @@ export const Wrapper = styled(WrapperTemplate)`
       font-size: 1.2rem;
     }
     p {
+      line-height: 1.5;
       margin: 0;
     }
   }
@@ -138,6 +139,7 @@ export const Wrapper = styled(WrapperTemplate)`
   }
   .decode-container {
     display: flex;
+    justify-content: space-between;
     flex: 1;
     div {
       align-items: flex-start !important;
@@ -153,12 +155,6 @@ export const Wrapper = styled(WrapperTemplate)`
     }
     ${media.mediumDown} {
       margin: 2rem 0;
-    }
-  }
-  .decode-section {
-    min-width: 45vh;
-    .hidden-content {
-      max-width: 40vh;
     }
   }
   .ipfs-container {

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -15,13 +15,19 @@ export const Wrapper = styled(WrapperTemplate)`
     line-height: 1.3;
     display: block;
     margin-bottom: 1rem;
+    ol {
+      padding-left: 2rem;
+      li {
+        margin: 0.5rem 0 0.5rem 0;
+      }
+    }
   }
   .info-header {
     margin-bottom: 2rem;
     font-size: 1.5rem;
     &.box {
       padding: 3rem 4rem;
-      background: #22232d;
+      background: ${({ theme }): string => theme.bg3};
       border-radius: 0.4rem;
     }
     a {
@@ -75,6 +81,10 @@ export const Wrapper = styled(WrapperTemplate)`
     .appData-hash {
       margin: 0 0 1rem 0;
       max-width: 54rem;
+      border: 1px solid ${({ theme }): string => theme.tableRowBorder};
+      padding: 0.75rem;
+      background: ${({ theme }): string => theme.tableRowBorder};
+      border-radius: 0.5rem;
       ${media.mobile} {
         max-width: none;
         margin: 1rem 0;

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -10,6 +10,17 @@ export const StyledExplorerTabs = styled(ExplorerTabs)`
 
 export const Wrapper = styled(WrapperTemplate)`
   max-width: 118rem;
+  .info-header {
+    margin-bottom: 2rem;
+    font-size: 1.5rem;
+    &.inner-form {
+      margin-bottom: 3rem;
+      font-size: 1.25rem;
+    }
+    p {
+      margin: 0;
+    }
+  }
   ${Content} {
     display: flex;
     flex-direction: column;
@@ -102,6 +113,11 @@ export const Wrapper = styled(WrapperTemplate)`
     flex: 1;
     div {
       align-items: flex-start !important;
+    }
+    .left-pannel {
+      display: flex;
+      flex-direction: column;
+      width: 40vw;
     }
     ${media.mobile} {
       margin: 2rem 0;

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -284,6 +284,9 @@ export const Wrapper = styled(WrapperTemplate)`
         font-size: 1.3rem;
         margin: 1rem 0;
       }
+      .main-container {
+        width: 100%;
+      }
       .data-form {
         width: 100%;
         max-width: 40rem;
@@ -291,6 +294,9 @@ export const Wrapper = styled(WrapperTemplate)`
         ${media.mobile} {
           max-width: 100%;
           margin-right: 0;
+        }
+        input {
+          margin-top: 1rem;
         }
       }
       .hidden-content {

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -32,13 +32,14 @@ export const Wrapper = styled(WrapperTemplate)`
     }
     a {
       margin: 0 0.5rem 0 0.5rem;
+      color: ${({ theme }): string => theme.orange};
     }
     &.inner-form {
       h2 {
         margin-bottom: 2rem;
       }
       margin-bottom: 3rem;
-      font-size: 1.25rem;
+      font-size: 1.2rem;
     }
     p {
       margin: 0;
@@ -152,6 +153,12 @@ export const Wrapper = styled(WrapperTemplate)`
     }
     ${media.mediumDown} {
       margin: 2rem 0;
+    }
+  }
+  .decode-section {
+    min-width: 45vh;
+    .hidden-content {
+      max-width: 40vh;
     }
   }
   .ipfs-container {

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -51,9 +51,13 @@ export const Wrapper = styled(WrapperTemplate)`
     flex-direction: column;
     border: 0;
     padding: 0;
+    .form-container {
+      ${AppDataWrapper} {
+        align-items: center;
+      }
+    }
     ${AppDataWrapper} {
       flex: 1;
-      align-items: center;
       padding-left: 2rem;
       ${media.mobile} {
         padding-left: 0;
@@ -62,10 +66,7 @@ export const Wrapper = styled(WrapperTemplate)`
     .json-formatter {
       line-height: 1.25;
       ${media.desktopMediumDown} {
-        max-width: 37vw;
-      }
-      ${media.mediumDownMd} {
-        max-width: 33vw;
+        max-width: 45vw;
       }
       ${media.mobile} {
         max-width: none;
@@ -141,9 +142,6 @@ export const Wrapper = styled(WrapperTemplate)`
     display: flex;
     gap: 10rem;
     flex: 1;
-    div {
-      align-items: center;
-    }
     .left-pannel {
       display: flex;
       flex-direction: column;

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -10,10 +10,27 @@ export const StyledExplorerTabs = styled(ExplorerTabs)`
 
 export const Wrapper = styled(WrapperTemplate)`
   max-width: 118rem;
+  .disclaimer {
+    font-size: 1.2rem;
+    line-height: 1.3;
+    display: block;
+    margin-bottom: 1rem;
+  }
   .info-header {
     margin-bottom: 2rem;
     font-size: 1.5rem;
+    &.box {
+      padding: 3rem 4rem;
+      background: #22232d;
+      border-radius: 0.4rem;
+    }
+    a {
+      margin: 0 0.5rem 0 0.5rem;
+    }
     &.inner-form {
+      h2 {
+        margin-bottom: 2rem;
+      }
       margin-bottom: 3rem;
       font-size: 1.25rem;
     }
@@ -143,10 +160,6 @@ export const Wrapper = styled(WrapperTemplate)`
     }
     p {
       padding-right: 0;
-    }
-    .disclaimer {
-      font-size: 1.2rem;
-      line-height: 1.3;
     }
   }
   button {

--- a/src/components/common/AppDataWrapper/index.tsx
+++ b/src/components/common/AppDataWrapper/index.tsx
@@ -41,7 +41,7 @@ const AppDataWrapper = styled.div`
         width: 95%;
       }
       ${media.mobile} {
-        width: 75vw;
+        width: 78vw;
       }
       ${media.tinyDown} {
         width: 70vw;

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import styled from 'styled-components'
 
 // Components
@@ -98,10 +98,19 @@ const Tabs: React.FC<Props> = (props) => {
 
   const [activeTab, setActiveTab] = useState(defaultTab)
 
-  function onTabClick(key: TabId): void {
-    setActiveTab(key)
-    onChange?.(key)
-  }
+  const onTabClick = useCallback(
+    (key: TabId): void => {
+      setActiveTab(key)
+      onChange?.(key)
+    },
+    [onChange],
+  )
+
+  useEffect(() => {
+    if (activeTab !== defaultTab) {
+      onTabClick(defaultTab)
+    }
+  }, [activeTab, defaultTab, onTabClick])
 
   return (
     <Wrapper>


### PR DESCRIPTION
# Summary

This PR add more context to the AppData page for the Encode and Decode tabs.

<img width="1193" alt="Screen Shot 2022-08-30 at 09 49 02" src="https://user-images.githubusercontent.com/11525018/187440887-a9b015d3-ff4e-43c1-b307-d3a6f5f48848.png">
<img width="1175" alt="Screen Shot 2022-08-30 at 09 49 22" src="https://user-images.githubusercontent.com/11525018/187440906-b3539b98-a60f-4bca-a4b5-96686b18aaad.png">
<img width="1204" alt="Screen Shot 2022-08-30 at 09 49 34" src="https://user-images.githubusercontent.com/11525018/187440921-33aa9018-a9db-469b-89e1-e5cbdf3da8dd.png">


# To Test

1.  Open the page `appdata`
     * You'll notice a message on the top of the `appdata` form.
2.  Generate an appdata document.
     * You'll notice a message on the top of the `IPFS` form.
3. Go to Decode tab
     * You'll notice a message on the top of the `appdata hash` form.

