### PR TITLE
[Appdata] json section position

### DIFF
--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -75,11 +75,13 @@ export const Wrapper = styled(WrapperTemplate)`
 
     .hidden-content {
       ${media.desktop} {
-        position: fixed;
+        position: sticky;
+        top: 2.8rem;
         width: 30vw;
       }
       ${media.mediumUp} {
-        position: fixed;
+        position: sticky;
+        top: 3rem;
         width: 35vw;
       }
       ${media.mobile} {
@@ -89,7 +91,8 @@ export const Wrapper = styled(WrapperTemplate)`
         font-size: 1.2rem;
       }
       ${media.desktopLarge} {
-        position: fixed;
+        position: sticky;
+        top: 4rem;
         width: 60rem;
       }
       h4 {


### PR DESCRIPTION
# Summary

Closes #199 
 Now json section does not overlap screen boarder.
Regarding borders:
On medium and small devices, we intentionally hide the borders on the main container. Visually, it looks more simple. 

# To test

1. Open AppData page https://pr209--explorer.review.gnosisdev.com/appdata?tab=encode
2. Fill in ALL the fields, press on the Generate button
3. Scroll down