### PR TITLE
[Tokens Table] Change query to use tokenHourlyTotals for tokens table

### DIFF
--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -179,23 +179,8 @@ export const GET_TOKENS_QUERY = gql`
 `
 
 export const GET_HISTORICAL_DATA_QUERY = gql`
-  query GetHistoricalData($address: ID!, $lastDayTimestamp: Int!, $lastWeekTimestamp: Int!) {
+  query GetHistoricalData($address: ID!, $lastWeekTimestamp: Int!) {
     tokenHourlyTotals(
-      first: 25
-      orderBy: timestamp
-      orderDirection: desc
-      where: { token: $address, timestamp_gt: $lastDayTimestamp }
-    ) {
-      token {
-        address
-      }
-      timestamp
-      totalVolumeUsd
-      averagePrice
-    }
-
-    tokenDailyTotals(
-      first: 8
       orderBy: timestamp
       orderDirection: desc
       where: { token: $address, timestamp_gt: $lastWeekTimestamp }
@@ -204,6 +189,7 @@ export const GET_HISTORICAL_DATA_QUERY = gql`
         address
       }
       timestamp
+      totalVolumeUsd
       averagePrice
     }
   }
@@ -226,15 +212,8 @@ export type TokenDailyTotals = {
   averagePrice: string
 }
 
-export type TokenWeeklyTotals = {
-  token: { address: string }
-  timestamp: number
-  averagePrice: string
-}
-
 export type SubgraphHistoricalDataResponse = {
   tokenHourlyTotals: Array<TokenDailyTotals>
-  tokenDailyTotals: Array<TokenWeeklyTotals>
 }
 
 export type Token = {
@@ -280,7 +259,6 @@ function enhanceNativeToken(tokens: TokenResponse[], network: Network): TokenRes
     if (!isNativeToken(token.address)) {
       return token
     }
-    console.log(NATIVE_TOKEN_PER_NETWORK[network], token)
     return {
       ...token,
       ...NATIVE_TOKEN_PER_NETWORK[network],

--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -205,7 +205,7 @@ export type TokenResponse = {
   totalVolumeUsd: string
 }
 
-export type TokenDailyTotals = {
+export type TokenHourlyTotals = {
   token: { address: string }
   timestamp: number
   totalVolumeUsd: string
@@ -213,7 +213,7 @@ export type TokenDailyTotals = {
 }
 
 export type SubgraphHistoricalDataResponse = {
-  tokenHourlyTotals: Array<TokenDailyTotals>
+  tokenHourlyTotals: Array<TokenHourlyTotals>
 }
 
 export type Token = {

--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -74,7 +74,7 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
     const lastDayPrice = data.tokenHourlyTotals.find(
       (x) => x.timestamp >= lastDayTimestampFrom && x.timestamp <= lastDayTimestampTo,
     )?.averagePrice
-    const lastWeekPrice = data.tokenDailyTotals.find(
+    const lastWeekPrice = data.tokenHourlyTotals.find(
       (x) => x.timestamp >= lastWeekTimestampFrom && x.timestamp <= lastWeekTimestampTo,
     )?.averagePrice
 
@@ -86,7 +86,7 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
       lastWeekPricePercentageDifference: lastWeekPrice
         ? getPercentageDifference(Number(priceUsd), Number(lastWeekPrice))
         : undefined,
-      lastWeekUsdPrices: data.tokenDailyTotals
+      lastWeekUsdPrices: data.tokenHourlyTotals
         .map((x) => ({
           time: Number(x.timestamp) as UTCTimestamp,
           value: Number(x.averagePrice),


### PR DESCRIPTION
# Summary

Closes #148 

Changed the `tokenDailyTotals` query by `tokenHourlyTotals` to increase data points in the chart.

<img width="1218" alt="Screen Shot 2022-09-08 at 12 00 15" src="https://user-images.githubusercontent.com/11525018/189157890-1566fa4d-d137-487d-b59b-0095e74650bd.png">


# To Test

1. Open the `home` page
    * Look at `Price (Last 7 days)` column. Data points in the chart have been increased to improve precision. 

