### PR TITLE
[Tokens Table] Sort by 24h volume

### DIFF
--- a/src/apps/explorer/components/TokensTableWidget/index.tsx
+++ b/src/apps/explorer/components/TokensTableWidget/index.tsx
@@ -101,7 +101,7 @@ export const TokensTableWidget: React.FC<Props> = () => {
     handleNextPage,
     handlePreviousPage,
   } = useTable({ initialState: { pageOffset: 0, pageSize: RESULTS_PER_PAGE } })
-  const { tokens, isLoading, error } = useGetTokens(networkId, tableState)
+  const { tokens, isLoading, error } = useGetTokens(networkId)
   const filteredTokens = useFlexSearch(query, tokens, ['name', 'symbol', 'address'])
   const resultsLength = query.length ? filteredTokens.length : tokens.length
 
@@ -121,6 +121,7 @@ export const TokensTableWidget: React.FC<Props> = () => {
 
   const filterData = (): Token[] => {
     const data = query ? (filteredTokens as Token[]) : tokens
+
     return data
       .map((token) => ({
         ...token,

--- a/src/apps/explorer/components/common/TextWithTooltip/index.tsx
+++ b/src/apps/explorer/components/common/TextWithTooltip/index.tsx
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
 `
 interface TextTooltipProps {
   children: React.ReactNode
-  textInTooltip: string
+  textInTooltip: string | React.ReactNode
   tooltipPlacement?: Placement
 }
 

--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -382,7 +382,7 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
                         ${formatPrice({ price: new BigNumber(lastDayUsdVolume), decimals: 2, thousands: true })}
                       </span>
                       <br />
-                      <span>Last Updated: {timestamp ? formatDate(timestamp * 1000, 'yyyy-MM-dd HH:mm') : ''}</span>
+                      <span>Last updated: {timestamp ? formatDate(timestamp * 1000, 'yyyy-MM-dd HH:mm') : ''}</span>
                     </>
                   ) : (
                     '$0'
@@ -432,7 +432,7 @@ const TokenTable: React.FC<Props> = (props) => {
         <>
           <tr className="header-row">
             <td>
-              <HeaderTitle className="mobile-header">Sorted by Volume(24h): From highest to lowest</HeaderTitle>
+              <HeaderTitle className="mobile-header">Sorted by Volume(24h): from highest to lowest</HeaderTitle>
             </td>
           </tr>
           {items.map((item, i) => (

--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -3,6 +3,7 @@ import styled, { DefaultTheme, useTheme } from 'styled-components'
 import { createChart, IChartApi } from 'lightweight-charts'
 import BigNumber from 'bignumber.js'
 import { formatPrice, TokenErc20 } from '@gnosis.pm/dex-js'
+import { fromUnixTime, startOfToday } from 'date-fns'
 
 import { Token } from 'hooks/useGetTokens'
 import { useNetworkId } from 'state/network'
@@ -19,7 +20,6 @@ import { numberFormatter } from 'apps/explorer/components/SummaryCardsWidget/uti
 import ShimmerBar from 'apps/explorer/components/common/ShimmerBar'
 import { TableState } from 'apps/explorer/components/TokensTableWidget/useTable'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
-import { formatDate } from 'utils'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead {
@@ -382,7 +382,9 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
                         ${formatPrice({ price: new BigNumber(lastDayUsdVolume), decimals: 2, thousands: true })}
                       </span>
                       <br />
-                      <span>Last updated: {timestamp ? formatDate(timestamp * 1000, 'yyyy-MM-dd HH:mm') : ''}</span>
+                      <span>From: {timestamp ? fromUnixTime(timestamp).toISOString() : ''}</span>
+                      <br />
+                      <span>To: {fromUnixTime(startOfToday().setUTCHours(0) / 1000).toISOString()}</span>
                     </>
                   ) : (
                     '$0'

--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -19,6 +19,7 @@ import { numberFormatter } from 'apps/explorer/components/SummaryCardsWidget/uti
 import ShimmerBar from 'apps/explorer/components/common/ShimmerBar'
 import { TableState } from 'apps/explorer/components/TokensTableWidget/useTable'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
+import { formatDate } from 'utils'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead {
@@ -253,6 +254,7 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
     lastWeekUsdPrices,
     lastWeekPricePercentageDifference,
     lastDayUsdVolume,
+    lastDayUsdTimestamp,
     totalVolumeUsd,
   } = token
   const erc20 = { name, address, symbol, decimals } as TokenErc20
@@ -345,7 +347,7 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
         )}
       </td>
       <td>
-        <HeaderTitle>Volume (24h)</HeaderTitle>
+        <HeaderTitle>Volume (24h)&darr;</HeaderTitle>
         {handleLoadingState(
           lastDayUsdVolume,
           <HeaderValue>
@@ -356,7 +358,7 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
                       price: new BigNumber(lastDayUsdVolume),
                       decimals: 2,
                       thousands: true,
-                    })}`
+                    })} - ${lastDayUsdTimestamp ? formatDate(lastDayUsdTimestamp * 1000, 'yyyy-MM-dd') : ''}`
                   : '$0'
               }
             >
@@ -420,7 +422,7 @@ const TokenTable: React.FC<Props> = (props) => {
           <th>Price</th>
           <th>Price (24h)</th>
           <th>Price (7d)</th>
-          <th>Volume (24h)</th>
+          <th>Volume (24h) &darr;</th>
           <th>Total volume</th>
           <th>Price (last 7 days)</th>
         </tr>

--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -32,6 +32,25 @@ const Wrapper = styled(StyledUserDetailsTable)`
     border-bottom: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
     > tr {
       min-height: 7.4rem;
+      &.header-row {
+        display: none;
+        ${media.mobile} {
+          display: flex;
+          background: transparent;
+          border: none;
+          padding: 0;
+          margin: 0;
+          box-shadow: none;
+          min-height: 2rem;
+          td {
+            padding: 0;
+            margin: 0;
+            .mobile-header {
+              margin: 0;
+            }
+          }
+        }
+      }
     }
     > tr > td:first-child {
       padding: 0 2rem;
@@ -47,7 +66,8 @@ const Wrapper = styled(StyledUserDetailsTable)`
     :nth-child(5),
     :nth-child(6),
     :nth-child(7) {
-      justify-content: right;
+      justify-content: center;
+      text-align: center;
     }
   }
   > tbody > tr > td:nth-child(8),
@@ -142,10 +162,6 @@ const HeaderTitle = styled.span`
     margin-right: 3rem;
     svg {
       margin-left: 5px;
-    }
-    &.mobile-header {
-      height: 2rem;
-      margin-left: 1rem;
     }
   }
 `
@@ -305,100 +321,95 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
   }
 
   return (
-    <>
-      <HeaderTitle className="mobile-header">Sorted by Volume(24h)</HeaderTitle>
-      <tr key={id}>
-        <td>
-          <HeaderTitle>#</HeaderTitle>
-          <HeaderValue>{index + 1}</HeaderValue>
-        </td>
-        <td>
-          <HeaderTitle>Name</HeaderTitle>
-          <TokenWrapper>
-            <TokenDisplay erc20={erc20} network={network} />
-          </TokenWrapper>
-        </td>
-        <td>
-          <HeaderTitle>Symbol</HeaderTitle>
-          <HeaderValue>{symbol}</HeaderValue>
-        </td>
-        <td>
-          <HeaderTitle>Price</HeaderTitle>
-          <HeaderValue>
-            <TextWithTooltip textInTooltip={`$${Number(priceUsd) || 0}`}>
-              ${Number(priceUsd) ? formatPrice({ price: new BigNumber(priceUsd), decimals: 4, thousands: true }) : 0}
-            </TextWithTooltip>
-          </HeaderValue>
-        </td>
-        <td>
-          <HeaderTitle>Price (24h)</HeaderTitle>
-          {handleLoadingState(
-            lastDayPricePercentageDifference,
-            <HeaderValue
-              captionColor={
-                lastDayPricePercentageDifference ? getColorBySign(lastDayPricePercentageDifference) : 'grey'
-              }
-            >
-              {lastDayPricePercentageDifference && lastDayPricePercentageDifference.toFixed(2)}%
-            </HeaderValue>,
-          )}
-        </td>
-        <td>
-          <HeaderTitle>Price (7d)</HeaderTitle>
-          {handleLoadingState(
-            lastWeekPricePercentageDifference,
-            <HeaderValue
-              captionColor={
-                lastWeekPricePercentageDifference ? getColorBySign(lastWeekPricePercentageDifference) : 'grey'
-              }
-            >
-              {lastWeekPricePercentageDifference && lastWeekPricePercentageDifference.toFixed(2)}%
-            </HeaderValue>,
-          )}
-        </td>
-        <td>
-          <HeaderTitle>Volume (24h)</HeaderTitle>
-          {handleLoadingState(
-            lastDayUsdVolume,
-            <HeaderValue>
-              <TextWithTooltip
-                textInTooltip={
-                  <TooltipWrapper>
-                    {lastDayUsdVolume ? (
-                      <>
-                        <span>
-                          ${formatPrice({ price: new BigNumber(lastDayUsdVolume), decimals: 2, thousands: true })}
-                        </span>
-                        <br />
-                        <span>Last Updated: {timestamp ? formatDate(timestamp * 1000, 'yyyy-MM-dd HH:mm') : ''}</span>
-                      </>
-                    ) : (
-                      '$0'
-                    )}
-                  </TooltipWrapper>
-                }
-              >
-                ${lastDayUsdVolume && numberFormatter(lastDayUsdVolume)}
-              </TextWithTooltip>
-            </HeaderValue>,
-          )}
-        </td>
-        <td>
-          <HeaderTitle>Total volume</HeaderTitle>
+    <tr key={id}>
+      <td>
+        <HeaderTitle>#</HeaderTitle>
+        <HeaderValue>{index + 1}</HeaderValue>
+      </td>
+      <td>
+        <HeaderTitle>Name</HeaderTitle>
+        <TokenWrapper>
+          <TokenDisplay erc20={erc20} network={network} />
+        </TokenWrapper>
+      </td>
+      <td>
+        <HeaderTitle>Symbol</HeaderTitle>
+        <HeaderValue>{symbol}</HeaderValue>
+      </td>
+      <td>
+        <HeaderTitle>Price</HeaderTitle>
+        <HeaderValue>
+          <TextWithTooltip textInTooltip={`$${Number(priceUsd) || 0}`}>
+            ${Number(priceUsd) ? formatPrice({ price: new BigNumber(priceUsd), decimals: 4, thousands: true }) : 0}
+          </TextWithTooltip>
+        </HeaderValue>
+      </td>
+      <td>
+        <HeaderTitle>Price (24h)</HeaderTitle>
+        {handleLoadingState(
+          lastDayPricePercentageDifference,
+          <HeaderValue
+            captionColor={lastDayPricePercentageDifference ? getColorBySign(lastDayPricePercentageDifference) : 'grey'}
+          >
+            {lastDayPricePercentageDifference && lastDayPricePercentageDifference.toFixed(2)}%
+          </HeaderValue>,
+        )}
+      </td>
+      <td>
+        <HeaderTitle>Price (7d)</HeaderTitle>
+        {handleLoadingState(
+          lastWeekPricePercentageDifference,
+          <HeaderValue
+            captionColor={
+              lastWeekPricePercentageDifference ? getColorBySign(lastWeekPricePercentageDifference) : 'grey'
+            }
+          >
+            {lastWeekPricePercentageDifference && lastWeekPricePercentageDifference.toFixed(2)}%
+          </HeaderValue>,
+        )}
+      </td>
+      <td>
+        <HeaderTitle>Volume (24h)</HeaderTitle>
+        {handleLoadingState(
+          lastDayUsdVolume,
           <HeaderValue>
             <TextWithTooltip
-              textInTooltip={`$${formatPrice({ price: new BigNumber(totalVolumeUsd), decimals: 2, thousands: true })}`}
+              textInTooltip={
+                <TooltipWrapper>
+                  {lastDayUsdVolume ? (
+                    <>
+                      <span>
+                        ${formatPrice({ price: new BigNumber(lastDayUsdVolume), decimals: 2, thousands: true })}
+                      </span>
+                      <br />
+                      <span>Last Updated: {timestamp ? formatDate(timestamp * 1000, 'yyyy-MM-dd HH:mm') : ''}</span>
+                    </>
+                  ) : (
+                    '$0'
+                  )}
+                </TooltipWrapper>
+              }
             >
-              ${numberFormatter(Number(totalVolumeUsd))}
+              ${lastDayUsdVolume && numberFormatter(lastDayUsdVolume)}
             </TextWithTooltip>
-          </HeaderValue>
-        </td>
-        <td>
-          <HeaderTitle>Price (last 7 days)</HeaderTitle>
-          {handleLoadingState(lastWeekUsdPrices, <ChartWrapper ref={chartContainerRef} />)}
-        </td>
-      </tr>
-    </>
+          </HeaderValue>,
+        )}
+      </td>
+      <td>
+        <HeaderTitle>Total volume</HeaderTitle>
+        <HeaderValue>
+          <TextWithTooltip
+            textInTooltip={`$${formatPrice({ price: new BigNumber(totalVolumeUsd), decimals: 2, thousands: true })}`}
+          >
+            ${numberFormatter(Number(totalVolumeUsd))}
+          </TextWithTooltip>
+        </HeaderValue>
+      </td>
+      <td>
+        <HeaderTitle>Price (last 7 days)</HeaderTitle>
+        {handleLoadingState(lastWeekUsdPrices, <ChartWrapper ref={chartContainerRef} />)}
+      </td>
+    </tr>
   )
 }
 
@@ -419,6 +430,11 @@ const TokenTable: React.FC<Props> = (props) => {
     } else {
       tableContent = (
         <>
+          <tr className="header-row">
+            <td>
+              <HeaderTitle className="mobile-header">Sorted by Volume(24h): From highest to lowest</HeaderTitle>
+            </td>
+          </tr>
           {items.map((item, i) => (
             <RowToken key={`${item.id}-${i}`} index={i + tableState.pageOffset} token={item} />
           ))}
@@ -439,7 +455,7 @@ const TokenTable: React.FC<Props> = (props) => {
           <th>Price</th>
           <th>Price (24h)</th>
           <th>Price (7d)</th>
-          <th>Volume (24h) &darr;</th>
+          <th>Volume (24h)&darr;</th>
           <th>Total volume</th>
           <th>Price (last 7 days)</th>
         </tr>

--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -77,7 +77,7 @@ const Wrapper = styled(StyledUserDetailsTable)`
       border: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
       box-shadow: 0px 4px 12px ${({ theme }): string => theme.boxShadow};
       border-radius: 6px;
-      margin-top: 16px;
+      margin-top: 10px;
       padding: 12px;
       &:hover {
         background: none;
@@ -143,6 +143,10 @@ const HeaderTitle = styled.span`
     svg {
       margin-left: 5px;
     }
+    &.mobile-header {
+      height: 2rem;
+      margin-left: 1rem;
+    }
   }
 `
 
@@ -165,13 +169,15 @@ const TokenWrapper = styled.div`
 
 const HeaderValue = styled.span<{ captionColor?: 'green' | 'red1' | 'grey' }>`
   color: ${({ theme, captionColor }): string => (captionColor ? theme[captionColor] : theme.textPrimary1)};
-
   ${media.mobile} {
     flex-wrap: wrap;
     text-align: end;
   }
 `
 
+const TooltipWrapper = styled.div`
+  text-align: center;
+`
 const ChartWrapper = styled.div`
   position: relative;
   ${media.mobile} {
@@ -254,8 +260,8 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
     lastWeekUsdPrices,
     lastWeekPricePercentageDifference,
     lastDayUsdVolume,
-    lastDayUsdTimestamp,
     totalVolumeUsd,
+    timestamp,
   } = token
   const erc20 = { name, address, symbol, decimals } as TokenErc20
   const network = useNetworkId()
@@ -299,89 +305,100 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
   }
 
   return (
-    <tr key={id}>
-      <td>
-        <HeaderTitle>#</HeaderTitle>
-        <HeaderValue>{index + 1}</HeaderValue>
-      </td>
-      <td>
-        <HeaderTitle>Name</HeaderTitle>
-        <TokenWrapper>
-          <TokenDisplay erc20={erc20} network={network} />
-        </TokenWrapper>
-      </td>
-      <td>
-        <HeaderTitle>Symbol</HeaderTitle>
-        <HeaderValue>{symbol}</HeaderValue>
-      </td>
-      <td>
-        <HeaderTitle>Price</HeaderTitle>
-        <HeaderValue>
-          <TextWithTooltip textInTooltip={`$${Number(priceUsd) || 0}`}>
-            ${Number(priceUsd) ? formatPrice({ price: new BigNumber(priceUsd), decimals: 4, thousands: true }) : 0}
-          </TextWithTooltip>
-        </HeaderValue>
-      </td>
-      <td>
-        <HeaderTitle>Price (24h)</HeaderTitle>
-        {handleLoadingState(
-          lastDayPricePercentageDifference,
-          <HeaderValue
-            captionColor={lastDayPricePercentageDifference ? getColorBySign(lastDayPricePercentageDifference) : 'grey'}
-          >
-            {lastDayPricePercentageDifference && lastDayPricePercentageDifference.toFixed(2)}%
-          </HeaderValue>,
-        )}
-      </td>
-      <td>
-        <HeaderTitle>Price (7d)</HeaderTitle>
-        {handleLoadingState(
-          lastWeekPricePercentageDifference,
-          <HeaderValue
-            captionColor={
-              lastWeekPricePercentageDifference ? getColorBySign(lastWeekPricePercentageDifference) : 'grey'
-            }
-          >
-            {lastWeekPricePercentageDifference && lastWeekPricePercentageDifference.toFixed(2)}%
-          </HeaderValue>,
-        )}
-      </td>
-      <td>
-        <HeaderTitle>Volume (24h)&darr;</HeaderTitle>
-        {handleLoadingState(
-          lastDayUsdVolume,
+    <>
+      <HeaderTitle className="mobile-header">Sorted by Volume(24h)</HeaderTitle>
+      <tr key={id}>
+        <td>
+          <HeaderTitle>#</HeaderTitle>
+          <HeaderValue>{index + 1}</HeaderValue>
+        </td>
+        <td>
+          <HeaderTitle>Name</HeaderTitle>
+          <TokenWrapper>
+            <TokenDisplay erc20={erc20} network={network} />
+          </TokenWrapper>
+        </td>
+        <td>
+          <HeaderTitle>Symbol</HeaderTitle>
+          <HeaderValue>{symbol}</HeaderValue>
+        </td>
+        <td>
+          <HeaderTitle>Price</HeaderTitle>
           <HeaderValue>
-            <TextWithTooltip
-              textInTooltip={
-                lastDayUsdVolume
-                  ? `$${formatPrice({
-                      price: new BigNumber(lastDayUsdVolume),
-                      decimals: 2,
-                      thousands: true,
-                    })} - ${lastDayUsdTimestamp ? formatDate(lastDayUsdTimestamp * 1000, 'yyyy-MM-dd') : ''}`
-                  : '$0'
+            <TextWithTooltip textInTooltip={`$${Number(priceUsd) || 0}`}>
+              ${Number(priceUsd) ? formatPrice({ price: new BigNumber(priceUsd), decimals: 4, thousands: true }) : 0}
+            </TextWithTooltip>
+          </HeaderValue>
+        </td>
+        <td>
+          <HeaderTitle>Price (24h)</HeaderTitle>
+          {handleLoadingState(
+            lastDayPricePercentageDifference,
+            <HeaderValue
+              captionColor={
+                lastDayPricePercentageDifference ? getColorBySign(lastDayPricePercentageDifference) : 'grey'
               }
             >
-              ${lastDayUsdVolume && numberFormatter(lastDayUsdVolume)}
+              {lastDayPricePercentageDifference && lastDayPricePercentageDifference.toFixed(2)}%
+            </HeaderValue>,
+          )}
+        </td>
+        <td>
+          <HeaderTitle>Price (7d)</HeaderTitle>
+          {handleLoadingState(
+            lastWeekPricePercentageDifference,
+            <HeaderValue
+              captionColor={
+                lastWeekPricePercentageDifference ? getColorBySign(lastWeekPricePercentageDifference) : 'grey'
+              }
+            >
+              {lastWeekPricePercentageDifference && lastWeekPricePercentageDifference.toFixed(2)}%
+            </HeaderValue>,
+          )}
+        </td>
+        <td>
+          <HeaderTitle>Volume (24h)</HeaderTitle>
+          {handleLoadingState(
+            lastDayUsdVolume,
+            <HeaderValue>
+              <TextWithTooltip
+                textInTooltip={
+                  <TooltipWrapper>
+                    {lastDayUsdVolume ? (
+                      <>
+                        <span>
+                          ${formatPrice({ price: new BigNumber(lastDayUsdVolume), decimals: 2, thousands: true })}
+                        </span>
+                        <br />
+                        <span>Last Updated: {timestamp ? formatDate(timestamp * 1000, 'yyyy-MM-dd HH:mm') : ''}</span>
+                      </>
+                    ) : (
+                      '$0'
+                    )}
+                  </TooltipWrapper>
+                }
+              >
+                ${lastDayUsdVolume && numberFormatter(lastDayUsdVolume)}
+              </TextWithTooltip>
+            </HeaderValue>,
+          )}
+        </td>
+        <td>
+          <HeaderTitle>Total volume</HeaderTitle>
+          <HeaderValue>
+            <TextWithTooltip
+              textInTooltip={`$${formatPrice({ price: new BigNumber(totalVolumeUsd), decimals: 2, thousands: true })}`}
+            >
+              ${numberFormatter(Number(totalVolumeUsd))}
             </TextWithTooltip>
-          </HeaderValue>,
-        )}
-      </td>
-      <td>
-        <HeaderTitle>Total volume</HeaderTitle>
-        <HeaderValue>
-          <TextWithTooltip
-            textInTooltip={`$${formatPrice({ price: new BigNumber(totalVolumeUsd), decimals: 2, thousands: true })}`}
-          >
-            ${numberFormatter(Number(totalVolumeUsd))}
-          </TextWithTooltip>
-        </HeaderValue>
-      </td>
-      <td>
-        <HeaderTitle>Price (last 7 days)</HeaderTitle>
-        {handleLoadingState(lastWeekUsdPrices, <ChartWrapper ref={chartContainerRef} />)}
-      </td>
-    </tr>
+          </HeaderValue>
+        </td>
+        <td>
+          <HeaderTitle>Price (last 7 days)</HeaderTitle>
+          {handleLoadingState(lastWeekUsdPrices, <ChartWrapper ref={chartContainerRef} />)}
+        </td>
+      </tr>
+    </>
   )
 }
 

--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -3,7 +3,7 @@ import styled, { DefaultTheme, useTheme } from 'styled-components'
 import { createChart, IChartApi } from 'lightweight-charts'
 import BigNumber from 'bignumber.js'
 import { formatPrice, TokenErc20 } from '@gnosis.pm/dex-js'
-import { fromUnixTime, startOfToday } from 'date-fns'
+import { format, fromUnixTime, startOfToday } from 'date-fns'
 
 import { Token } from 'hooks/useGetTokens'
 import { useNetworkId } from 'state/network'
@@ -382,9 +382,9 @@ const RowToken: React.FC<RowProps> = ({ token, index }) => {
                         ${formatPrice({ price: new BigNumber(lastDayUsdVolume), decimals: 2, thousands: true })}
                       </span>
                       <br />
-                      <span>From: {timestamp ? fromUnixTime(timestamp).toISOString() : ''}</span>
+                      <span>From: {timestamp ? format(fromUnixTime(timestamp), 'P pp zzzz') : ''}</span>
                       <br />
-                      <span>To: {fromUnixTime(startOfToday().setUTCHours(0) / 1000).toISOString()}</span>
+                      <span>To: {format(fromUnixTime(startOfToday().setUTCHours(0) / 1000), 'P pp zzzz')}</span>
                     </>
                   ) : (
                     '$0'

--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -14,7 +14,7 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
 
   const processTokenData = useCallback(
     (data: SubgraphHistoricalDataResponse, lastDayUsdVolume: number, timestamp: number) => {
-      const { averagePrice: priceUsd } = data.tokenHourlyTotals.slice(-1)[0]
+      const { averagePrice: priceUsd } = data.tokenHourlyTotals[0]
       const lastDayTimestampFrom = Number(lastHoursTimestamp(25))
       const lastDayTimestampTo = Number(lastHoursTimestamp(23))
       const lastWeekTimestampFrom = Number(lastDaysTimestamp(8))
@@ -124,7 +124,12 @@ export const GET_TOKENS_QUERY = gql`
         decimals
         totalVolumeUsd
         priceUsd
-        hourlyTotals(first: 1000, where: { timestamp_gt: $lastWeekTimestamp }) {
+        hourlyTotals(
+          first: 1000
+          orderBy: timestamp
+          orderDirection: desc
+          where: { timestamp_gt: $lastWeekTimestamp }
+        ) {
           timestamp
           averagePrice
         }

--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -3,68 +3,16 @@ import { gql } from '@apollo/client'
 import { subDays, subHours } from 'date-fns'
 import { Network, UiError } from 'types'
 import { COW_SDK, NATIVE_TOKEN_PER_NETWORK } from 'const'
-import { TableState } from 'apps/explorer/components/TokensTableWidget/useTable'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 import { UTCTimestamp } from 'lightweight-charts'
 import { getPercentageDifference, isNativeToken } from 'utils'
 
-export function useGetTokens(networkId: Network | undefined, tableState: TableState): GetTokensResult {
+export function useGetTokens(networkId: Network | undefined): GetTokensResult {
   const [isLoading, setIsLoading] = useState(false)
-  const [historicalDataLoaded, setHistoricalDataLoaded] = useState<{ [pageIndex: string]: boolean }>({})
   const [error, setError] = useState<UiError>()
   const [tokens, setTokens] = useState<Token[]>([])
 
-  const fetchTokens = useCallback(
-    async (network: Network): Promise<void> => {
-      setIsLoading(true)
-      setTokens([])
-      setHistoricalDataLoaded({})
-      try {
-        const response = await COW_SDK.cowSubgraphApi.runQuery<{ tokens: TokenResponse[] }>(
-          GET_TOKENS_QUERY,
-          undefined,
-          { chainId: network },
-        )
-        if (response) {
-          const tokens = enhanceNativeToken(response.tokens, network)
-          setTokens(tokens)
-        }
-      } catch (e) {
-        const msg = `Failed to fetch tokens`
-        console.error(msg, e)
-        setError({ message: msg, type: 'error' })
-      } finally {
-        setIsLoading(false)
-      }
-    },
-    [setTokens],
-  )
-
-  const getTokens = useCallback(
-    (tokenIds: string[]): { [tokenId: string]: Promise<SubgraphHistoricalDataResponse> | undefined } => {
-      const lastDayTimestamp = Number(lastHoursTimestamp(25)) // last 25 hours
-      const lastWeekTimestamp = Number(lastDaysTimestamp(8)) // last 8 days
-      const responses = {}
-      for (const tokenId of tokenIds) {
-        const response = COW_SDK.cowSubgraphApi.runQuery<SubgraphHistoricalDataResponse>(
-          GET_HISTORICAL_DATA_QUERY,
-          {
-            address: tokenId,
-            lastDayTimestamp,
-            lastWeekTimestamp,
-          },
-          { chainId: networkId },
-        )
-        responses[tokenId] = response
-      }
-
-      return responses
-    },
-    [networkId],
-  )
-
-  const processTokenData = useCallback((data: SubgraphHistoricalDataResponse) => {
-    const lastDayUsdVolume = data.tokenHourlyTotals.reduce((acc, curr) => acc + Number(curr.totalVolumeUsd), 0)
+  const processTokenData = useCallback((data: SubgraphHistoricalDataResponse, lastDayUsdVolume: number) => {
     const priceUsd = data.tokenHourlyTotals[0]?.averagePrice
 
     const lastDayTimestampFrom = Number(lastHoursTimestamp(25))
@@ -79,6 +27,7 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
     )?.averagePrice
 
     return {
+      lastDayUsdTimestamp: lastDayTimestampFrom,
       lastDayUsdVolume,
       lastDayPricePercentageDifference: lastDayPrice
         ? getPercentageDifference(Number(priceUsd), Number(lastDayPrice))
@@ -95,33 +44,43 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
     }
   }, [])
 
-  const getTokensHistoricalData = useCallback(
-    async (tokenIds: string[]): Promise<{ [tokenId: string]: TokenData } | void> => {
+  const fetchTokens = useCallback(
+    async (network: Network): Promise<void> => {
       setIsLoading(true)
+      setTokens([])
+      const lastDayTimestamp = Number(lastHoursTimestamp(25)) // last 25 hours
+      const lastWeekTimestamp = Number(lastDaysTimestamp(8)) // last 8 days
       try {
-        const tokens = await getTokens(tokenIds)
-        const tokensData = {} as { [tokenId: string]: TokenData }
-
-        for (const address of Object.keys(tokens)) {
-          const response = await tokens[address]
-          if (!response) {
-            continue
+        const response = await COW_SDK.cowSubgraphApi.runQuery<{ tokenDailyTotals: TokenDailyTotalsResponse[] }>(
+          GET_TOKENS_QUERY,
+          {
+            lastDayTimestamp,
+            lastWeekTimestamp,
+          },
+          { chainId: network },
+        )
+        if (response) {
+          const tokensData = {} as { [tokenId: string]: TokenData }
+          for (const tokenDailyTotal of response.tokenDailyTotals) {
+            const { token, totalVolumeUsd } = tokenDailyTotal
+            const tokenData = processTokenData({ tokenHourlyTotals: token.hourlyTotals }, Number(totalVolumeUsd))
+            tokensData[token.address] = { ...tokenData }
           }
-
-          const tokenData = processTokenData(response)
-          tokensData[address] = { ...tokenData }
+          const tokens = addHistoricalData(
+            response.tokenDailyTotals.map((tokenDaily) => tokenDaily.token),
+            tokensData,
+          )
+          setTokens(enhanceNativeToken(tokens, network))
         }
-
-        return tokensData
       } catch (e) {
-        const msg = `Failed to fetch tokens' data`
+        const msg = `Failed to fetch tokens`
         console.error(msg, e)
         setError({ message: msg, type: 'error' })
       } finally {
         setIsLoading(false)
       }
     },
-    [getTokens, processTokenData],
+    [processTokenData],
   )
 
   useEffect(() => {
@@ -131,29 +90,6 @@ export function useGetTokens(networkId: Network | undefined, tableState: TableSt
 
     fetchTokens(networkId)
   }, [fetchTokens, networkId])
-
-  useEffect(() => {
-    if (tokens.length === 0 || !networkId || !tableState.pageIndex || historicalDataLoaded[tableState.pageIndex]) {
-      return
-    }
-
-    const pageTokens = tokens.slice(
-      (tableState.pageIndex - 1) * tableState.pageSize,
-      tableState.pageIndex * tableState.pageSize,
-    )
-    const tokenIds = pageTokens.map((token) => token.id)
-
-    const setHistoricalData = async function (): Promise<void> {
-      const historicalData = await getTokensHistoricalData(tokenIds)
-
-      if (historicalData) {
-        setTokens((tokens) => [...addHistoricalData(tokens, historicalData)])
-        setHistoricalDataLoaded((loaded) => ({ ...loaded, [tableState.pageIndex || 0]: true }))
-      }
-    }
-
-    setHistoricalData()
-  }, [tableState.pageIndex, tableState.pageSize, tokens, networkId, getTokensHistoricalData, historicalDataLoaded])
 
   return { tokens, error, isLoading }
 }
@@ -165,36 +101,37 @@ type GetTokensResult = {
 }
 
 export const GET_TOKENS_QUERY = gql`
-  query GetTokens {
-    tokens(first: 50, orderBy: totalVolumeUsd, orderDirection: desc, where: { totalVolumeUsd_not: null }) {
-      id
-      address
-      name
-      symbol
-      decimals
-      totalVolumeUsd
-      priceUsd
-    }
-  }
-`
-
-export const GET_HISTORICAL_DATA_QUERY = gql`
-  query GetHistoricalData($address: ID!, $lastWeekTimestamp: Int!) {
-    tokenHourlyTotals(
-      orderBy: timestamp
+  query GetTokens($lastDayTimestamp: Int!, $lastWeekTimestamp: Int!) {
+    tokenDailyTotals(
+      first: 50
+      orderBy: totalVolumeUsd
       orderDirection: desc
-      where: { token: $address, timestamp_gt: $lastWeekTimestamp }
+      where: { timestamp_gt: $lastDayTimestamp }
     ) {
-      token {
-        address
-      }
       timestamp
       totalVolumeUsd
-      averagePrice
+      token {
+        id
+        address
+        name
+        symbol
+        decimals
+        totalVolumeUsd
+        priceUsd
+        hourlyTotals(where: { timestamp_gt: $lastWeekTimestamp }) {
+          timestamp
+          averagePrice
+        }
+      }
     }
   }
 `
 
+export type TokenDailyTotalsResponse = {
+  timestamp: number
+  totalVolumeUsd: string
+  token: TokenResponse
+}
 export type TokenResponse = {
   id: string
   name: string
@@ -203,6 +140,7 @@ export type TokenResponse = {
   decimals: number
   priceUsd: string
   totalVolumeUsd: string
+  hourlyTotals: TokenHourlyTotals[]
 }
 
 export type TokenHourlyTotals = {
@@ -219,6 +157,7 @@ export type SubgraphHistoricalDataResponse = {
 export type Token = {
   lastDayPricePercentageDifference?: number | null
   lastWeekPricePercentageDifference?: number | null
+  lastDayUsdTimestamp?: number | null
   lastDayUsdVolume?: number | null
   lastWeekUsdPrices?: Array<{ time: UTCTimestamp; value: number }> | null
 } & TokenResponse &
@@ -228,19 +167,20 @@ function addHistoricalData(tokens: Token[], prices: { [tokenId: string]: TokenDa
   for (const address of Object.keys(prices)) {
     const token = tokens.find((token) => token.address === address)
     const values = prices[address]
-
     if (token) {
       token.lastDayUsdVolume = values.lastDayUsdVolume
+      token.lastDayUsdTimestamp = values.lastDayUsdTimestamp
       token.lastDayPricePercentageDifference = values.lastDayPricePercentageDifference
       token.lastWeekPricePercentageDifference = values.lastWeekPricePercentageDifference
       token.lastWeekUsdPrices = values.lastWeekUsdPrices
     }
   }
-  return tokens
+  return tokens.sort((a, b) => (b.lastDayUsdVolume ?? -1) - (a.lastDayUsdVolume ?? -1))
 }
 
 export type TokenData = {
   lastDayUsdVolume?: number
+  lastDayUsdTimestamp?: number
   lastDayPricePercentageDifference?: number
   lastWeekPricePercentageDifference?: number
   lastWeekUsdPrices?: Array<{ time: UTCTimestamp; value: number }>

--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -13,8 +13,7 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
   const [tokens, setTokens] = useState<Token[]>([])
 
   const processTokenData = useCallback((data: SubgraphHistoricalDataResponse, lastDayUsdVolume: number) => {
-    const priceUsd = data.tokenHourlyTotals[0]?.averagePrice
-
+    const { averagePrice: priceUsd, timestamp } = data.tokenHourlyTotals.slice(-1)[0]
     const lastDayTimestampFrom = Number(lastHoursTimestamp(25))
     const lastDayTimestampTo = Number(lastHoursTimestamp(23))
     const lastWeekTimestampFrom = Number(lastDaysTimestamp(8))
@@ -27,7 +26,7 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
     )?.averagePrice
 
     return {
-      lastDayUsdTimestamp: lastDayTimestampFrom,
+      timestamp,
       lastDayUsdVolume,
       lastDayPricePercentageDifference: lastDayPrice
         ? getPercentageDifference(Number(priceUsd), Number(lastDayPrice))
@@ -157,8 +156,8 @@ export type SubgraphHistoricalDataResponse = {
 export type Token = {
   lastDayPricePercentageDifference?: number | null
   lastWeekPricePercentageDifference?: number | null
-  lastDayUsdTimestamp?: number | null
   lastDayUsdVolume?: number | null
+  timestamp?: number | null
   lastWeekUsdPrices?: Array<{ time: UTCTimestamp; value: number }> | null
 } & TokenResponse &
   TokenErc20
@@ -168,8 +167,8 @@ function addHistoricalData(tokens: Token[], prices: { [tokenId: string]: TokenDa
     const token = tokens.find((token) => token.address === address)
     const values = prices[address]
     if (token) {
+      token.timestamp = values.timestamp
       token.lastDayUsdVolume = values.lastDayUsdVolume
-      token.lastDayUsdTimestamp = values.lastDayUsdTimestamp
       token.lastDayPricePercentageDifference = values.lastDayPricePercentageDifference
       token.lastWeekPricePercentageDifference = values.lastWeekPricePercentageDifference
       token.lastWeekUsdPrices = values.lastWeekUsdPrices
@@ -179,8 +178,8 @@ function addHistoricalData(tokens: Token[], prices: { [tokenId: string]: TokenDa
 }
 
 export type TokenData = {
+  timestamp?: number
   lastDayUsdVolume?: number
-  lastDayUsdTimestamp?: number
   lastDayPricePercentageDifference?: number
   lastWeekPricePercentageDifference?: number
   lastWeekUsdPrices?: Array<{ time: UTCTimestamp; value: number }>

--- a/src/hooks/useGetTokens.ts
+++ b/src/hooks/useGetTokens.ts
@@ -59,7 +59,7 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
           { chainId: network },
         )
         if (response) {
-          const tokensData = {} as { [tokenId: string]: TokenData }
+          const tokensData: { [tokenId: string]: TokenData } = {}
           for (const tokenDailyTotal of response.tokenDailyTotals) {
             const { token, totalVolumeUsd } = tokenDailyTotal
             const tokenData = processTokenData({ tokenHourlyTotals: token.hourlyTotals }, Number(totalVolumeUsd))


### PR DESCRIPTION
# Summary

Closes #210 

- Refactor code to get tokens table info in just one query to the subgraph.
- Sort the tokens table by 24h Volume instead of Total Volume.

<img width="1251" alt="Screen Shot 2022-09-14 at 00 38 18" src="https://user-images.githubusercontent.com/11525018/190054577-4d8917c6-5c7c-4a07-bcee-562adf627cfb.png">


# To Test

1.  Open the `home` page and wait for the tokens table to load.
*  You'll see the tokens table is now sorted by 24h volume.


