### PR TITLE
Fetch solvers names

### DIFF
--- a/src/apps/explorer/pages/Home/index.tsx
+++ b/src/apps/explorer/pages/Home/index.tsx
@@ -8,6 +8,7 @@ import { useNetworkId } from 'state/network'
 import { TokensTableWidget } from 'apps/explorer/components/TokensTableWidget'
 import { Helmet } from 'react-helmet'
 import { APP_TITLE } from 'apps/explorer/const'
+import { useSolversInfo } from 'hooks/useSolversInfo'
 
 const Wrapper = styled(WrapperMod)`
   max-width: 140rem;
@@ -48,6 +49,12 @@ const SummaryWrapper = styled.section`
 
 export const Home: React.FC = () => {
   const networkId = useNetworkId() || undefined
+
+  // TODO: remove me!!!
+  const solverInfo = useSolversInfo(networkId)
+
+  console.log('solver info', solverInfo)
+
   return (
     <Wrapper>
       <Helmet>

--- a/src/hooks/useSolversInfo.ts
+++ b/src/hooks/useSolversInfo.ts
@@ -1,0 +1,16 @@
+import { fetchSolversInfo, SolversInfo } from 'utils/fetchSolversInfo'
+import { useEffect, useState } from 'react'
+
+export function useSolversInfo(network?: number): SolversInfo {
+  const [info, setInfo] = useState<SolversInfo>([])
+
+  useEffect(() => {
+    if (network) {
+      fetchSolversInfo(network).then(setInfo)
+    } else {
+      setInfo([])
+    }
+  }, [network])
+
+  return info
+}

--- a/src/utils/fetchSolversInfo.ts
+++ b/src/utils/fetchSolversInfo.ts
@@ -1,0 +1,66 @@
+export type SolverInfo = {
+  address: string
+  name: string
+  environment: string
+}
+
+export type SolversInfo = SolverInfo[]
+
+const SOLVER_SOURCE_PER_NETWORK = {
+  1: 'https://raw.githubusercontent.com/duneanalytics/spellbook/main/models/cow_protocol/ethereum/cow_protocol_ethereum_solvers.sql',
+  100: 'https://raw.githubusercontent.com/duneanalytics/spellbook/main/deprecated-dune-v1-abstractions/xdai/gnosis_protocol_v2/view_solvers.sql',
+}
+
+/**
+ * This is a very dirty temporary solution to get the solver info dynamically
+ *
+ * The source file is a SQL with the structure that we care about looking like:
+ * FROM (VALUES ('0xf2d21ad3c88170d4ae52bbbeba80cb6078d276f4', 'prod', 'MIP'),
+ *              ('0x15f4c337122ec23859ec73bec00ab38445e45304', 'prod', 'Gnosis_ParaSwap'),
+ * The regex below extracts the 3 fields we are looking for and ignore the rest
+ */
+const REGEX = /\('(0x[0-9a-fA-F]{40})',\s*'(\w+)',\s*'([\w\s]+)'\)/g
+
+const SOLVERS_INFO_CACHE: Record<number, SolversInfo> = {}
+
+export async function fetchSolversInfo(network: number): Promise<SolversInfo> {
+  const url = SOLVER_SOURCE_PER_NETWORK[network]
+
+  if (!url) {
+    return []
+  }
+
+  const cache = SOLVERS_INFO_CACHE[network]
+  if (cache) {
+    return cache
+  }
+
+  try {
+    const response = await fetch(url)
+    const result = _parseSolverInfo(await response.text())
+
+    SOLVERS_INFO_CACHE[network] = result
+
+    return result
+  } catch (e) {
+    console.error(`Failed to fetch solvers info from '${url}'`)
+    return []
+  }
+}
+
+function _parseSolverInfo(body: string): SolversInfo {
+  const info: SolversInfo = []
+
+  const matches = body.matchAll(REGEX)
+
+  // Each match has 4 entries:
+  // 1. The whole capture group
+  // 2. The address
+  // 3. The environment
+  // 4. The name
+  for (const [, address, environment, name] of matches) {
+    info.push({ address, environment, name })
+  }
+
+  return info
+}


### PR DESCRIPTION
# Summary

Very dirty work around to dynamically fetch solver info

Has only Mainnet and Gnosis Chain (no test networks)

Temporarily added the new hook to home page just for testing. Will remove before merging

# To Test

1. Load home page and open the console
2. Filter by `solver info`
* On default network (mainnet) it should have 57 items in the array
<img width="530" alt="Screen Shot 2022-09-27 at 17 20 58" src="https://user-images.githubusercontent.com/43217/192581009-bcd0000e-7dcd-4a9e-a70e-36417869fad8.png">

3. Change to gchain
* It should contain 21 items in the array
4. Switch to Goerli/Rinkeby.
* Should be an empty array

The results should be cached. If you check the network tab, there should be only 1 request per network (mainnet & gchain).
<img width="656" alt="Screen Shot 2022-09-27 at 17 24 02" src="https://user-images.githubusercontent.com/43217/192581794-5a9afe37-adda-43de-8d78-a35701110fc2.png">
