### PR TITLE
Inter var font improvements

### DIFF
--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -226,7 +226,6 @@ export const Wrapper = styled(WrapperTemplate)`
     padding: 0.8rem 1.5rem;
     transition-duration: 0.2s;
     transition-timing-function: ease-in-out;
-    font-family: 'Inter var', sans-serif;
 
     ${media.mobile} {
       margin: 1rem 0 0 0;

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -34,8 +34,7 @@ export const OptionsContainer = styled.div<{ width: number }>`
 export const Option = styled.div`
   display: flex;
   flex: 1;
-  font-family: var(--font-avenir);
-  font-weight: 800;
+  font-weight: 600;
   font-size: 13px;
   line-height: 18px;
   align-items: center;

--- a/src/components/NetworkSelector/NetworkSelector.styled.ts
+++ b/src/components/NetworkSelector/NetworkSelector.styled.ts
@@ -34,7 +34,7 @@ export const OptionsContainer = styled.div<{ width: number }>`
 export const Option = styled.div`
   display: flex;
   flex: 1;
-  font-weight: 600;
+  font-weight: 800;
   font-size: 13px;
   line-height: 18px;
   align-items: center;

--- a/src/theme/styles/global.ts
+++ b/src/theme/styles/global.ts
@@ -71,7 +71,6 @@ export const ThemedGlobalStyle = createGlobalStyle`
   textarea,
   button {
     font-family: ${({ theme }): string => theme.fontDefault}, sans-serif;
-    font-display: fallback;
   }
   @supports (font-variation-settings: normal) {
     input,
@@ -86,6 +85,7 @@ export const ThemedGlobalStyle = createGlobalStyle`
     /* StyleLint fights you for the sans-serif as it requires a fallback and can't detect it from the theme prop */
     font-family: ${({ theme }): string => theme.fontDefault}, sans-serif;
     font-feature-settings: 'ss01' on, 'ss02' on;
+    font-display: fallback;
 
     @supports (font-variation-settings: normal) {
       font-family: ${({ theme }): string => theme.fontVariable}, sans-serif;

--- a/src/theme/styles/global.ts
+++ b/src/theme/styles/global.ts
@@ -67,11 +67,25 @@ export const StaticGlobalStyle = createGlobalStyle`
 `
 
 export const ThemedGlobalStyle = createGlobalStyle`
+  input,
+  textarea,
+  button {
+    font-family: ${({ theme }): string => theme.fontDefault}, sans-serif;
+    font-display: fallback;
+  }
+  @supports (font-variation-settings: normal) {
+    input,
+    textarea,
+    button {
+      font-family: ${({ theme }): string => theme.fontVariable}, sans-serif;
+    }
+  }
   html, body {
     background: ${({ theme }): string => theme.bg1};
     color: ${({ theme }): string => theme.textPrimary1};
     /* StyleLint fights you for the sans-serif as it requires a fallback and can't detect it from the theme prop */
     font-family: ${({ theme }): string => theme.fontDefault}, sans-serif;
+    font-feature-settings: 'ss01' on, 'ss02' on, 'cv01' on, 'cv03' on;
 
     @supports (font-variation-settings: normal) {
       font-family: ${({ theme }): string => theme.fontVariable}, sans-serif;

--- a/src/theme/styles/global.ts
+++ b/src/theme/styles/global.ts
@@ -85,7 +85,7 @@ export const ThemedGlobalStyle = createGlobalStyle`
     color: ${({ theme }): string => theme.textPrimary1};
     /* StyleLint fights you for the sans-serif as it requires a fallback and can't detect it from the theme prop */
     font-family: ${({ theme }): string => theme.fontDefault}, sans-serif;
-    font-feature-settings: 'ss01' on, 'ss02' on, 'cv01' on, 'cv03' on;
+    font-feature-settings: 'ss01' on, 'ss02' on;
 
     @supports (font-variation-settings: normal) {
       font-family: ${({ theme }): string => theme.fontVariable}, sans-serif;


### PR DESCRIPTION
# Summary

Closes #219
Inter font documentation:
https://rsms.me/inter/#features/zero

Before:
![image](https://user-images.githubusercontent.com/622217/192847999-ca144f57-1412-4b10-a271-67d2fd0750b2.png)

After: 
![image](https://user-images.githubusercontent.com/622217/192847876-93d305a3-376c-41ae-b0ab-aa9ddaf37bfd.png)

# To Test

1. <<Step one>> Open the page `Home`
* Search boxes should have Inter var font by default.

> Before:
> ![image](https://user-images.githubusercontent.com/622217/192848370-48e47425-1969-4bed-966b-f6653846762d.png)
> After:
> ![image](https://user-images.githubusercontent.com/622217/192848340-cf98a412-8abf-4603-96ef-9e4cddb81636.png)


* Check that the texts and numbers now have a new look (more similar as in CoWSwap). Some stylistics sets were added:
![image](https://user-images.githubusercontent.com/622217/192847805-0952bff4-bf8f-40dd-bdc4-65520bb749ed.png)
