### PR TITLE
Merge prod and barn user orders

### DIFF
--- a/src/api/operator/accountOrderUtils.ts
+++ b/src/api/operator/accountOrderUtils.ts
@@ -1,0 +1,92 @@
+import { OrderMetaData, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { COW_SDK } from 'const'
+
+import { GetAccountOrdersParams, RawOrder } from './types'
+
+/**
+ * Gets a list of orders of one user paginated
+ *
+ * Optional filters:
+ *  - owner: address
+ *  - offset: int
+ *  - limit: int
+ */
+export async function getAccountOrders(params: GetAccountOrdersParams): Promise<RawOrder[]> {
+  const { networkId, owner, offset = 0, limit = 20 } = params
+  const state = getState({ networkId, owner, limit })
+
+  const currentPage = Math.round(offset / limit)
+  const cachedPageOrders = state.merged.get(currentPage)
+
+  if (cachedPageOrders) {
+    return [...cachedPageOrders]
+  }
+
+  const [prodOrders, barnOrders] = await Promise.all([
+    state.prodHasNext ? COW_SDK.cowApi.getOrders({ owner, offset, limit }, { chainId: networkId, env: 'prod' }) : [],
+    state.barnHasNext ? COW_SDK.cowApi.getOrders({ owner, offset, limit }, { chainId: networkId, env: 'staging' }) : [],
+  ])
+
+  state.prodHasNext = prodOrders.length === limit
+  if (state.prodHasNext) {
+    state.prodPage += 1
+  }
+
+  state.barnHasNext = barnOrders.length === limit
+  if (state.barnHasNext) {
+    state.barnPage += 1
+  }
+
+  const mergedEnvs = [...prodOrders, ...barnOrders, ...state.unmerged]
+    .filter((v, i, a) => a.findIndex((v2) => v2.uid === v.uid) === i) // remove duplicated orders
+    .sort((o1, o2) => new Date(o2.creationDate).getTime() - new Date(o1.creationDate).getTime())
+
+  const currentPageOrders = mergedEnvs.slice(0, limit)
+  state.merged.set(currentPage, currentPageOrders)
+
+  if (mergedEnvs.length > limit) {
+    state.unmerged = mergedEnvs.slice(limit)
+  } else {
+    state.unmerged = []
+  }
+
+  return [...currentPageOrders]
+}
+
+const userOrdersCache = new Map<string, CacheState>()
+
+type CacheKey = {
+  networkId: SupportedChainId
+  owner: string
+  limit: number
+}
+
+type CacheState = {
+  merged: Map<number, OrderMetaData[]>
+  unmerged: OrderMetaData[]
+  prodPage: number
+  prodHasNext: boolean
+  barnPage: number
+  barnHasNext: boolean
+}
+
+const emptyState = (): CacheState => ({
+  merged: new Map<number, OrderMetaData[]>(),
+  unmerged: [] as OrderMetaData[],
+  prodPage: 0,
+  prodHasNext: true,
+  barnPage: 0,
+  barnHasNext: true,
+})
+
+const getState = (cacheKey: CacheKey): CacheState => {
+  const key = JSON.stringify(cacheKey)
+  const cachedState = userOrdersCache.get(key)
+
+  if (!cachedState) {
+    userOrdersCache.set(key, emptyState())
+    console.debug('User Orders: Cache reset', { key })
+  }
+
+  return userOrdersCache.get(key) ?? emptyState()
+}

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -2,34 +2,15 @@ import { GetTradesParams } from '@cowprotocol/cow-sdk'
 import { Network } from 'types'
 import { COW_SDK } from 'const'
 import { buildSearchString } from 'utils/url'
-import { environmentName, Envs, isProd, isStaging } from 'utils/env'
+import { isProd, isStaging } from 'utils/env'
 
-import {
-  GetOrderParams,
-  GetAccountOrdersParams,
-  GetOrdersParams,
-  RawOrder,
-  RawTrade,
-  GetTxOrdersParams,
-  WithNetworkId,
-} from './types'
+import { GetOrderParams, GetOrdersParams, RawOrder, RawTrade, GetTxOrdersParams, WithNetworkId } from './types'
 import { fetchQuery } from 'api/baseApi'
+
+export { getAccountOrders } from './accountOrderUtils'
 
 // TODO: export this through the sdk
 export type ApiEnv = 'prod' | 'staging'
-
-function explorerToApiEnv(explorerEnv?: Envs): ApiEnv {
-  switch (explorerEnv) {
-    case 'production':
-    case 'staging':
-      return 'prod'
-    case 'development':
-    case 'barn':
-      return 'staging'
-    default:
-      return 'prod'
-  }
-}
 
 // TODO: should come from the SDK by now, find out where this is used
 function getOperatorUrl(): Partial<Record<Network, string>> {
@@ -115,21 +96,6 @@ export async function getOrders(params: GetOrdersParams): Promise<RawOrder[]> {
   const queryString = '/orders/' + searchString
 
   return _fetchQuery(networkId, queryString)
-}
-
-/**
- * Gets a list of orders of one user paginated
- *
- * Optional filters:
- *  - owner: address
- *  - offset: int
- *  - limit: int
- */
-export async function getAccountOrders(params: GetAccountOrdersParams): Promise<RawOrder[]> {
-  const { networkId, owner, offset, limit } = params
-  // since we are not merging responses yet, we fix the sdk env to the current one
-  const env = explorerToApiEnv(environmentName)
-  return COW_SDK.cowApi.getOrders({ owner, offset, limit }, { chainId: networkId, env })
 }
 
 /**


### PR DESCRIPTION
# Summary

Closes #149

The solution uses a local cache to keep track of the orders that comes from either the [Production API](https://api.cow.fi/docs/) or the [Barn API](https://barn.api.cow.fi/docs/) and merges the responses so the client side pagination doesn't break.

# To Test

1. Use an account that has many prod and barn orders such as `0x2db8323b3766b868aaf6a967e55eeb35c233de9d`
* Open https://explorer.cow.fi/goerli/address/0x2db8323b3766b868aaf6a967e55eeb35c233de9d to see only orders from the Production API
* Open https://protocol-explorer.dev.gnosisdev.com/goerli/address/0x2db8323b3766b868aaf6a967e55eeb35c233de9d to see only orders from the Barn API
* Open <> to validate the responses are merged
