### PR TITLE
Replace blockscout with gnosisscan

### DIFF
--- a/src/components/common/BlockExplorerLink/BlockExplorerLink.tsx
+++ b/src/components/common/BlockExplorerLink/BlockExplorerLink.tsx
@@ -41,7 +41,9 @@ export interface Props {
 }
 
 function getEtherscanUrlPrefix(networkId: Network): string {
-  return !networkId || networkId === Network.MAINNET ? '' : (Network[networkId] || '').toLowerCase() + '.'
+  return !networkId || networkId === Network.MAINNET || networkId === Network.GNOSIS_CHAIN
+    ? ''
+    : (Network[networkId] || '').toLowerCase() + '.'
 }
 
 function getEtherscanUrlSuffix(type: BlockExplorerLinkType, identifier: string): string {
@@ -59,43 +61,14 @@ function getEtherscanUrlSuffix(type: BlockExplorerLinkType, identifier: string):
   }
 }
 
-function getBlockscoutUrlPrefix(networkId: number): string {
-  switch (networkId) {
-    case Network.GNOSIS_CHAIN:
-      return 'poa/xdai'
-
-    default:
-      return ''
-  }
-}
-
-function getBlockscoutUrlSuffix(type: BlockExplorerLinkType, identifier: string): string {
-  switch (type) {
-    case 'tx':
-      return `tx/${identifier}`
-    case 'event':
-      return `tx/${identifier}/logs`
-    case 'address':
-      return `address/${identifier}/transactions`
-    case 'contract':
-      return `address/${identifier}/contracts`
-    case 'token':
-      return `tokens/${identifier}/token-transfers`
-  }
-}
-
-function getBlockscoutUrl(networkId: number, type: BlockExplorerLinkType, identifier: string): string {
-  return `https://blockscout.com/${getBlockscoutUrlPrefix(networkId)}/${getBlockscoutUrlSuffix(type, identifier)}`
-}
-
-function getEtherscanUrl(networkId: number, type: BlockExplorerLinkType, identifier: string): string {
-  return `https://${getEtherscanUrlPrefix(networkId)}etherscan.io/${getEtherscanUrlSuffix(type, identifier)}`
+function getEtherscanUrl(host: string, networkId: number, type: BlockExplorerLinkType, identifier: string): string {
+  return `https://${getEtherscanUrlPrefix(networkId)}${host}/${getEtherscanUrlSuffix(type, identifier)}`
 }
 
 function getExplorerUrl(networkId: number, type: BlockExplorerLinkType, identifier: string): string {
   return networkId === Network.GNOSIS_CHAIN
-    ? getBlockscoutUrl(networkId, type, identifier)
-    : getEtherscanUrl(networkId, type, identifier)
+    ? getEtherscanUrl('gnosisscan.io', networkId, type, identifier)
+    : getEtherscanUrl('etherscan.io', networkId, type, identifier)
 }
 
 /**
@@ -117,7 +90,12 @@ export const BlockExplorerLink: React.FC<Props> = (props: Props) => {
   return (
     <ExternalLink href={url} target="_blank" rel="noopener noreferrer" className={className}>
       <span>{label}</span>
-      {showLogo && <LogoWrapper title="Open it on Etherscan" src={LOGO_MAP.etherscan} />}
+      {showLogo && (
+        <LogoWrapper
+          title={`Open it on ${networkId === Network.GNOSIS_CHAIN ? 'Gnosisscan' : 'Etherscan'}`}
+          src={LOGO_MAP.etherscan}
+        />
+      )}
     </ExternalLink>
   )
 }

--- a/src/hooks/useGetOrders.tsx
+++ b/src/hooks/useGetOrders.tsx
@@ -175,7 +175,7 @@ export function useTxOrderExplorerLink(
             networkId: network,
             identifier: txHash,
             showLogo: true,
-            label: network === Network.GNOSIS_CHAIN ? 'Blockscout' : 'Etherscan',
+            label: network === Network.GNOSIS_CHAIN ? 'Gnosisscan' : 'Etherscan',
           })
         }
       })

--- a/test/components/BlockExplorerLink.components.test.tsx
+++ b/test/components/BlockExplorerLink.components.test.tsx
@@ -78,7 +78,7 @@ describe('<BlockExplorerLink type="tx"/>', () => {
   it('renders link to xDai', () => {
     networkId = Network.GNOSIS_CHAIN
     const wrapper = render(<BlockExplorerLink type="tx" identifier={TX_HASH} />)
-    expect(wrapper.prop('href')).toMatch(`https://blockscout.com/poa/xdai/tx/${TX_HASH}`)
+    expect(wrapper.prop('href')).toMatch(`https://gnosisscan.io/tx/${TX_HASH}`)
   })
 })
 
@@ -96,7 +96,7 @@ describe('<BlockExplorerLink type="address"/>', () => {
   it('renders link to xDai', () => {
     networkId = Network.GNOSIS_CHAIN
     const wrapper = render(<BlockExplorerLink type="address" identifier={USER_1} />)
-    expect(wrapper.prop('href')).toMatch(`https://blockscout.com/poa/xdai/address/${USER_1}/transactions`)
+    expect(wrapper.prop('href')).toMatch(`https://gnosisscan.io/address/${USER_1}`)
   })
 })
 
@@ -113,7 +113,7 @@ describe('<BlockExplorerLink type="contract"/>', () => {
   it('renders link to xDai', () => {
     networkId = Network.GNOSIS_CHAIN
     const wrapper = render(<BlockExplorerLink type="contract" identifier={CONTRACT} />)
-    expect(wrapper.prop('href')).toMatch(`https://blockscout.com/poa/xdai/address/${CONTRACT}/contracts`)
+    expect(wrapper.prop('href')).toMatch(`https://gnosisscan.io/address/${CONTRACT}#code`)
   })
 })
 
@@ -130,6 +130,6 @@ describe('<BlockExplorerLink type="token"/>', () => {
   it('renders link to xDai', () => {
     networkId = Network.GNOSIS_CHAIN
     const wrapper = render(<BlockExplorerLink type="token" identifier={TOKEN_1} />)
-    expect(wrapper.prop('href')).toMatch(`https://blockscout.com/poa/xdai/tokens/${TOKEN_1}/token-transfers`)
+    expect(wrapper.prop('href')).toMatch(`https://gnosisscan.io/token/${TOKEN_1}`)
   })
 })


### PR DESCRIPTION
# Summary

Closes #207 

Replace [Blockscout](https://blockscout.com/xdai/mainnet) urls with [Gnosiscan](https://gnosisscan.io/)

# To Test

1. Open
* Tx page: https://pr247--explorer.review.gnosisdev.com/gc/tx/0x611f0d1358e2d67059b6de651023cedf34f1f09ea4d0b0c559f26ff749db0318?tab=orders and verify the `Open in Gnosisscan` link works
* Address page: https://pr247--explorer.review.gnosisdev.com/gc/address/0xa86c52669910a3749ca09f193cc3094f971230c9 and verify the `Open in Gnosisscan` link works
* Token page: https://pr247--explorer.review.gnosisdev.com/gc and verify the tokens links points to Gnosisscan
