### PR TITLE
Improve loading state in User details

### DIFF
--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -19,6 +19,7 @@ export const OrdersTableWithData: React.FC = () => {
     isLoading: searchInAnotherNetworkState,
     ordersInNetworks,
     setLoadingState,
+    errorMsg: error,
   } = useSearchInAnotherNetwork(networkId, ownerAddress, orders)
 
   useEffect(() => {
@@ -54,6 +55,7 @@ export const OrdersTableWithData: React.FC = () => {
           ordersInNetworks={ordersInNetworks}
           ownerAddress={ownerAddress}
           setLoadingState={setLoadingState}
+          errorMsg={error}
         />
       }
     />

--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -59,11 +59,13 @@ interface ResultSearchInAnotherNetwork {
   isLoading: boolean
   ordersInNetworks: OrdersInNetwork[]
   setLoadingState: (value: boolean) => void
+  errorMsg: string | null
 }
 
 type EmptyMessageProps = ResultSearchInAnotherNetwork & {
   networkId: BlockchainNetwork
   ownerAddress: string
+  errorMsg: string | null
 }
 
 const _findNetworkName = (networkId: number): string => {
@@ -82,6 +84,7 @@ export const EmptyOrdersMessage = ({
   ordersInNetworks,
   ownerAddress,
   setLoadingState,
+  errorMsg: hasErrorMsg,
 }: EmptyMessageProps): JSX.Element => {
   const areOtherNetworks = ordersInNetworks.length > 0
 
@@ -92,7 +95,11 @@ export const EmptyOrdersMessage = ({
   return (
     <Wrapper>
       {!areOtherNetworks ? (
-        <p>No orders found.</p>
+        hasErrorMsg ? (
+          <p>{hasErrorMsg}</p>
+        ) : (
+          <p>No orders found.</p>
+        )
       ) : (
         <>
           <p>
@@ -136,10 +143,12 @@ export const useSearchInAnotherNetwork = (
   const [ordersInNetworks, setOrdersInNetworks] = useState<OrdersInNetwork[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const isOrdersLengthZero = !orders || orders.length === 0
+  const [error, setError] = useState<string | null>(null)
 
   const fetchAnotherNetworks = useCallback(
     async (_networkId: Network) => {
       setIsLoading(true)
+      setError(null)
       const promises = NETWORK_ID_SEARCH_LIST.filter((net) => net !== _networkId).map((network) =>
         getAccountOrders({ networkId: network, owner: ownerAddress, offset: 0, limit: 1 })
           .then((response) => {
@@ -148,6 +157,8 @@ export const useSearchInAnotherNetwork = (
             return { network }
           })
           .catch((e) => {
+            // Msg for when there are no orders on any network and a request has failed
+            setError('An error has occurred while requesting the data.')
             console.error(`Failed to fetch order in ${Network[network]}`, e)
           }),
       )
@@ -167,5 +178,5 @@ export const useSearchInAnotherNetwork = (
     fetchAnotherNetworks(networkId)
   }, [fetchAnotherNetworks, isOrdersLengthZero, networkId])
 
-  return { isLoading, ordersInNetworks, setLoadingState: setIsLoading }
+  return { isLoading, ordersInNetworks, setLoadingState: setIsLoading, errorMsg: error }
 }

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -21,7 +21,7 @@ import Icon from 'components/Icon'
 import TradeOrderType from 'components/common/TradeOrderType'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
-import CowLoading from 'components/common/CowLoading'
+import Spinner from 'components/common/Spinner'
 import { OrderSurplusDisplayStyledByRow } from './OrderSurplusTooltipStyledByRow'
 
 const Wrapper = styled(StyledUserDetailsTable)`
@@ -167,7 +167,7 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
   }
 
   const renderSpinnerWhenNoValue = (textValue: string): JSX.Element | void => {
-    if (textValue === '-') return <CowLoading />
+    if (textValue === '-') return <Spinner spin size="1x" />
   }
 
   return (

--- a/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -21,7 +21,7 @@ import Icon from 'components/Icon'
 import TradeOrderType from 'components/common/TradeOrderType'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
-import Spinner from 'components/common/Spinner'
+import CowLoading from 'components/common/CowLoading'
 import { OrderSurplusDisplayStyledByRow } from './OrderSurplusTooltipStyledByRow'
 
 const Wrapper = styled(StyledUserDetailsTable)`
@@ -167,7 +167,7 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
   }
 
   const renderSpinnerWhenNoValue = (textValue: string): JSX.Element | void => {
-    if (textValue === '-') return <Spinner spin size="1x" />
+    if (textValue === '-') return <CowLoading />
   }
 
   return (


### PR DESCRIPTION
# Summary

Closes #163

Handles the case where the app searches for orders in different networks when there are no orders in the current network: The CoWLoading component appears until the network requests complete.

# To Test

1. While in the ETHEREUM network selector, go to the landing and search for `0x1811be0994930fE9480eAEDe25165608B093ad7A`
2. No intermediate state should appear while searching through all the networks:
- No `No orders found.` message
- No spinner
