### PR TITLE
Showing an error msg when there are no orders due to failed requests

### DIFF
--- a/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -19,6 +19,7 @@ export const OrdersTableWithData: React.FC = () => {
     isLoading: searchInAnotherNetworkState,
     ordersInNetworks,
     setLoadingState,
+    errorMsg: error,
   } = useSearchInAnotherNetwork(networkId, ownerAddress, orders)
 
   useEffect(() => {
@@ -54,6 +55,7 @@ export const OrdersTableWithData: React.FC = () => {
           ordersInNetworks={ordersInNetworks}
           ownerAddress={ownerAddress}
           setLoadingState={setLoadingState}
+          errorMsg={error}
         />
       }
     />

--- a/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/src/apps/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -158,7 +158,7 @@ export const useSearchInAnotherNetwork = (
           })
           .catch((e) => {
             // Msg for when there are no orders on any network and a request has failed
-            setError('An erros has occurred while requesting the data.')
+            setError('An error has occurred while requesting the data.')
             console.error(`Failed to fetch order in ${Network[network]}`, e)
           }),
       )


### PR DESCRIPTION
# Summary

**Proposal:**
Showing  an error msg when there are no orders due to failed requests


![image (2)](https://user-images.githubusercontent.com/4270166/198665174-557b7a9b-5a27-48ab-8a46-306742360f86.png)

## To test

- While in the ETHEREUM network selector, go to the landing and search for `0x1811be0994930fE9480eAEDe25165608B093ad7A`

- Block API request from browser tools

- You will see a message indicating that the request has failed.