### PR TITLE
Update Solvers data from subgraph

### DIFF
--- a/src/components/solver/ActiveSolverTable/index.tsx
+++ b/src/components/solver/ActiveSolverTable/index.tsx
@@ -13,12 +13,11 @@ import StyledUserDetailsTable, {
 } from '../../common/StyledUserDetailsTable'
 
 import { media } from 'theme/styles/media'
-import { BlockExplorerLink } from 'components/common/BlockExplorerLink'
-import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import Identicon from 'components/common/Identicon'
 import { numberFormatter } from 'apps/explorer/components/SummaryCardsWidget/utils'
 import { TextWithTooltip } from 'apps/explorer/components/common/TextWithTooltip'
+import { DateDisplay } from 'components/common/DateDisplay'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead {
@@ -180,7 +179,8 @@ interface RowProps {
 }
 
 const RowSolver: React.FC<RowProps> = ({ solver }) => {
-  const { id, name, address, numberOfTrades, numberOfSettlements, solvedAmountUsd } = solver
+  const { id, name, address, numberOfTrades, numberOfSettlements, solvedAmountUsd, lastIsSolverUpdateTimestamp } =
+    solver
   const network = useNetworkId()
 
   if (!network) {
@@ -219,20 +219,8 @@ const RowSolver: React.FC<RowProps> = ({ solver }) => {
         <HeaderValue>{numberOfSettlements}</HeaderValue>
       </td>
       <td>
-        <HeaderTitle>Solver address</HeaderTitle>
-        <HeaderValue>
-          <RowWithCopyButton
-            textToCopy={address}
-            contentsToDisplay={
-              <BlockExplorerLink
-                type="address"
-                networkId={network}
-                identifier={address}
-                label={abbreviateString(address, 6, 4)}
-              />
-            }
-          />
-        </HeaderValue>
+        <HeaderTitle>Active since</HeaderTitle>
+        <HeaderValue>{<DateDisplay date={new Date(lastIsSolverUpdateTimestamp * 1000)} showIcon={true} />}</HeaderValue>
       </td>
     </tr>
   )
@@ -278,7 +266,7 @@ const SolverTable: React.FC<Props> = (props) => {
           <th>Trades</th>
           <th>Total volume&darr;</th>
           <th>Total settlements</th>
-          <th>Solver address</th>
+          <th>Active since</th>
         </tr>
       }
       body={solverItems(solvers)}

--- a/src/components/solver/SettlementTable/index.tsx
+++ b/src/components/solver/SettlementTable/index.tsx
@@ -3,9 +3,10 @@ import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
 import { formatPrice } from '@gnosis.pm/dex-js'
 import { useNetworkId } from 'state/network'
-import { abbreviateString } from 'utils'
+import { abbreviateString, FormatAmountPrecision, formattingAmountPrecision } from 'utils'
 import { Settlement } from 'hooks/useGetSettlements'
 import { TableState } from 'hooks/useTable'
+import { NATIVE_TOKEN_PER_NETWORK } from 'const'
 
 import StyledUserDetailsTable, {
   StyledUserDetailsTableProps,
@@ -189,6 +190,7 @@ const RowSettlement: React.FC<RowProps> = ({ settlement }) => {
     trades = [],
     tokens = [],
     totalVolumeUsd,
+    txCostNative,
     firstTradeTimestamp,
   } = settlement
   const network = useNetworkId()
@@ -238,8 +240,15 @@ const RowSettlement: React.FC<RowProps> = ({ settlement }) => {
         </HeaderValue>
       </td>
       <td>
-        <HeaderTitle>ETH cost</HeaderTitle>
-        <HeaderValue>-</HeaderValue>
+        <HeaderTitle>Tx cost</HeaderTitle>
+        <HeaderValue>
+          {formattingAmountPrecision(
+            new BigNumber(txCostNative),
+            NATIVE_TOKEN_PER_NETWORK[network],
+            FormatAmountPrecision.middlePrecision,
+          )}{' '}
+          {NATIVE_TOKEN_PER_NETWORK[network].symbol}
+        </HeaderValue>
       </td>
       <td>
         <HeaderTitle>Total volume</HeaderTitle>
@@ -301,7 +310,7 @@ const SettlementTable: React.FC<Props> = (props) => {
           <th>Tx hash</th>
           <th>Trades</th>
           <th>Tokens</th>
-          <th>ETH cost</th>
+          <th>Tx cost</th>
           <th>Total volume</th>
           <th>Timestamp&darr;</th>
         </tr>

--- a/src/components/solver/SolverDetailsTable/index.tsx
+++ b/src/components/solver/SolverDetailsTable/index.tsx
@@ -3,9 +3,10 @@ import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
 import { formatPrice } from '@gnosis.pm/dex-js'
 import { useNetworkId } from 'state/network'
-import { abbreviateString } from 'utils'
+import { abbreviateString, FormatAmountPrecision, formattingAmountPrecision } from 'utils'
 import { Settlement } from 'hooks/useGetSettlements'
 import { TableState } from 'hooks/useTable'
+import { NATIVE_TOKEN_PER_NETWORK } from 'const'
 
 import StyledUserDetailsTable, {
   StyledUserDetailsTableProps,
@@ -174,7 +175,7 @@ interface RowProps {
 }
 
 const RowSettlement: React.FC<RowProps> = ({ settlement }) => {
-  const { id, txHash, trades = [], tokens = [], totalVolumeUsd, firstTradeTimestamp } = settlement
+  const { id, txHash, trades = [], tokens = [], totalVolumeUsd, firstTradeTimestamp, txCostNative } = settlement
   const network = useNetworkId()
 
   if (!network) {
@@ -211,8 +212,15 @@ const RowSettlement: React.FC<RowProps> = ({ settlement }) => {
         </HeaderValue>
       </td>
       <td>
-        <HeaderTitle>ETH cost</HeaderTitle>
-        <HeaderValue>-</HeaderValue>
+        <HeaderTitle>Tx cost</HeaderTitle>
+        <HeaderValue>
+          {formattingAmountPrecision(
+            new BigNumber(txCostNative),
+            NATIVE_TOKEN_PER_NETWORK[network],
+            FormatAmountPrecision.middlePrecision,
+          )}{' '}
+          {NATIVE_TOKEN_PER_NETWORK[network].symbol}
+        </HeaderValue>
       </td>
       <td>
         <HeaderTitle>Total volume</HeaderTitle>
@@ -273,7 +281,7 @@ const SolverDetailsTable: React.FC<Props> = (props) => {
           <th>Tx hash</th>
           <th>Trades</th>
           <th>Tokens</th>
-          <th>ETH cost</th>
+          <th>Tx cost</th>
           <th>Total volume</th>
           <th>Timestamp&darr;</th>
         </tr>

--- a/src/hooks/useGetSettlements.ts
+++ b/src/hooks/useGetSettlements.ts
@@ -94,12 +94,11 @@ export type Settlement = {
   txHash: string
   solver: {
     address: string
-    numberOfTrades: number
   }
   trades: Trade[]
   tokens: TokenErc20[]
   totalVolumeUsd: number
-  ethCost: number
+  txCostNative: string
 }
 
 type Trade = {
@@ -114,9 +113,9 @@ const settlementsData = `
   id
   firstTradeTimestamp
   txHash
+  txCostNative
   solver {
     address
-    numberOfTrades
   }
   trades {
     sellAmountUsd

--- a/src/hooks/useGetSolvers.ts
+++ b/src/hooks/useGetSolvers.ts
@@ -62,16 +62,10 @@ const addExtraInfo = async (
   const solversInfo = await fetchSolversInfo(network)
   return await Promise.all(
     solvers.map(async (solver) => {
-      const { settlements } = await COW_SDK.cowSubgraphApi.runQuery<{ settlements: Settlement[] }>(
-        GET_SETTLEMENTS_QUERY,
-        { solver: solver.id },
-        { chainId: network },
-      )
       const sInfo = solversInfo.find((s) => s.address.toLowerCase() === solver.address.toLowerCase())
       return {
         ...solver,
         ...sInfo,
-        numberOfSettlements: settlements.length,
         ...ACTIVE_SOLVERS[solver.address],
       }
     }),
@@ -86,6 +80,7 @@ export type Solver = {
   numberOfTrades: number
   numberOfSettlements: number
   solvedAmountUsd: number
+  lastIsSolverUpdateTimestamp: number
 }
 
 export type Settlement = {
@@ -94,19 +89,13 @@ export type Settlement = {
 
 export const GET_SOLVERS_QUERY = gql`
   query GetSolvers {
-    users(first: 100, where: { isSolver: true }) {
+    users(first: 1000, where: { isSolver: true }) {
       id
       address
       numberOfTrades
       solvedAmountUsd
-    }
-  }
-`
-
-export const GET_SETTLEMENTS_QUERY = gql`
-  query GetSettlements($solver: String) {
-    settlements(where: { solver: $solver }) {
-      id
+      numberOfSettlements
+      lastIsSolverUpdateTimestamp
     }
   }
 `


### PR DESCRIPTION
# Summary

This update brings the changes done in the subgraph to the Solvers UI:

1. Active solvers:
  * Total settlements: Now the total settlements count is correct
  * Active since: Replaced Solver address column
2. Settlements: 
  * Tx cost: Renamed from ETH cost to be compatible with xDai
3. Solver details:
  * Total settlements: Now the total settlements count is correct
  * Active since: Now the card displays the correct value. If the solver is inactive it changes the wording to reflect that

<img width="896" alt="image" src="https://user-images.githubusercontent.com/3328006/198707972-49fa5572-8c5c-4605-bfc4-d641fb5f25e0.png">

<img width="895" alt="image" src="https://user-images.githubusercontent.com/3328006/198708011-085b1a7a-facf-4a9e-bb47-c21fff301158.png">

<img width="902" alt="image" src="https://user-images.githubusercontent.com/3328006/198708093-53475e9c-eac0-4873-9fd8-913f6a122091.png">

# Testing

The changes in the subgraphs need to be deployed and synced:
1. https://thegraph.com/hosted-service/subgraph/cowprotocol/cow
2. https://thegraph.com/hosted-service/subgraph/cowprotocol/cow-gc
3. https://thegraph.com/hosted-service/subgraph/cowprotocol/cow-goerli