### PR TITLE
Display order type (limit|market|liquidity)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "0.0.1-RC.5",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^1.0.1-RC.0",
+    "@cowprotocol/cow-sdk": "^1.0.1-RC.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -20,7 +20,10 @@ export type RawOrder = OrderMetaData
  * Applies some transformations on the raw api data.
  * Some fields are kept as is.
  */
-export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature'> & {
+export type Order = Pick<
+  RawOrder,
+  'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature' | 'class'
+> & {
   receiver: string
   txHash?: string
   shortId: string

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -84,14 +84,15 @@ const tooltip = {
     'The date and time at which an order will expire and effectively be cancelled. Depending on the type of order, it may have partial fills upon expiration.',
   type: (
     <div>
-      CoW Protocol supports three type of orders: market, limit and liquidity
+      CoW Protocol supports three type of orders – market, limit and liquidity:
       <ul>
-        <li>Market order is an order to buy or sell at the market&apos;s current best available price</li>
-        <li>Limit order is an order to buy or sell at an arbitrary price specified by the user</li>
-        <li>Liquidity order is an order that market makers can provide as a source of liquidity</li>
+        <li>A market order is an order to buy or sell at the market&apos;s current best available price</li>
+        <li>A limit order is an order to buy or sell at an arbitrary price specified by the user</li>
+        <li>A liquidity order is an order that market makers can provide as a source of liquidity</li>
       </ul>
-      In addition, an order can be &quot;Fill, Kill or Partially Fillable&quot;. Currently only market orders are
-      allowed to be partially fillable, while the other orders are just fill or kill.
+      In addition, an order can be &quot;fill or kill&quot; or &quot;partially fillable&quot;. Currently all order types
+      can be &quot;fill or kill&quot; – only market orders can be either &quot;fill or kill&quot; or &quot;partially
+      fillable&quot;.
     </div>
   ),
   amount: 'The total sell and buy amount for this order. Sell amount includes the fee.',

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -84,14 +84,14 @@ const tooltip = {
     'The date and time at which an order will expire and effectively be cancelled. Depending on the type of order, it may have partial fills upon expiration.',
   type: (
     <div>
-      There are three types of orders: market, limit and liquidity:
+      CoW Protocol supports three type of orders: market, limit and liquidity
       <ul>
-        <li>Market order is intended for trading at the current market price</li>
-        <li>Using a limit order, an arbitrary price can be specified</li>
-        <li>Liquidity order is a source of trusted liquidity providers</li>
+        <li>Market order is an order to buy or sell at the market&apos;s current best available price</li>
+        <li>Limit order is an order to buy or sell at an arbitrary price specified by the user</li>
+        <li>Liquidity order is an order that market makers can provide as a source of liquidity</li>
       </ul>
-      These orders can be either a Buy or Sell order. In addition, an order may be of type &quot;Fill or Kill&quot; (no
-      partial fills) or a regular order (partial fills allowed).
+      In addition, an order can be &quot;Fill, Kill or Partially Fillable&quot;. Currently only market orders are
+      allowed to be partially fillable, while the other orders are just fill or kill.
     </div>
   ),
   amount: 'The total sell and buy amount for this order. Sell amount includes the fee.',

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -82,7 +82,18 @@ const tooltip = {
     'The date and time at which the order was submitted. The timezone is based on the browser locale settings.',
   expiration:
     'The date and time at which an order will expire and effectively be cancelled. Depending on the type of order, it may have partial fills upon expiration.',
-  type: 'An order can be either a Buy or Sell order. In addition, an order may be of type "Fill or Kill" (no partial fills) or a regular order (partial fills allowed).',
+  type: (
+    <div>
+      There are three types of orders: market, limit and liquidity:
+      <ul>
+        <li>Market order is intended for trading at the current market price</li>
+        <li>Using a limit order, an arbitrary price can be specified</li>
+        <li>Liquidity order is a source of trusted liquidity providers</li>
+      </ul>
+      These orders can be either a Buy or Sell order. In addition, an order may be of type &quot;Fill or Kill&quot; (no
+      partial fills) or a regular order (partial fills allowed).
+    </div>
+  ),
   amount: 'The total sell and buy amount for this order. Sell amount includes the fee.',
   priceLimit:
     'The limit price is the price at which this order shall be (partially) filled, in combination with the specified slippage. The fee is already deduced from the sell amount',
@@ -272,7 +283,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.type} /> Type
             </td>
             <td>
-              {capitalize(kind)} order {!partiallyFillable && '(Fill or Kill)'}
+              {capitalize(kind)} {order.class} order {!partiallyFillable && '(Fill or Kill)'}
             </td>
           </tr>
           <tr>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,10 +1286,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^1.0.1-RC.0":
-  version "1.0.1-RC.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.0.tgz#3c0716581cd73ec909320df9267839e03b793155"
-  integrity sha512-1UKTJo7LmXp6Jm1l8CTd2blh8gIHear8/uD+KzGutXLp6YXDGc97oU88yfLNcPGN2OTEiq+tu/X3SvALCIwQ8w==
+"@cowprotocol/cow-sdk@^1.0.1-RC.2":
+  version "1.0.1-RC.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.2.tgz#ff47827679005e8b958b11c517a84c047497eae4"
+  integrity sha512-c0VFaSsz3/1W0X5//KFnO4qeWfD45Cj6UGO5kfQvmFcKMadQGYDDoQ+1o2QLzg4HHKc6BiamHvdx9ceJKQyrcA==
   dependencies:
     "@cowprotocol/app-data" "^0.0.1"
     "@cowprotocol/contracts" "^1.3.1"


### PR DESCRIPTION
# Summary

Closes https://github.com/cowprotocol/cowswap/issues/1346

There are three types of orders: `limit|market|liquidity`.
The label of type has format: `{Sell|buy} {limit|market|liquidity} order <(Fill or Kill)>`

<img width="482" alt="image" src="https://user-images.githubusercontent.com/7122625/203547053-3d69b248-8b86-4fbe-8c1b-d5acd1080a88.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/7122625/203547085-ef952790-5a19-4b7e-ad7d-7e4050978f2d.png">

<img width="508" alt="image" src="https://user-images.githubusercontent.com/7122625/203547148-2f019ab6-ea2b-4705-8474-109656715636.png">

<img width="507" alt="image" src="https://user-images.githubusercontent.com/7122625/203547273-db291f62-b17f-46c7-bda8-99f871b04aea.png">

<img width="528" alt="image" src="https://user-images.githubusercontent.com/7122625/203547374-06d41ee8-8364-4368-8129-df4d5ab172d0.png">

<img width="422" alt="image" src="https://user-images.githubusercontent.com/7122625/203547406-dcb5fc06-1552-47ce-992e-bb466d52045d.png">

