### PR TITLE
Hide Fee row from order details for not filled limit-orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "0.0.1-RC.5",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^1.0.1-RC.0",
+    "@cowprotocol/cow-sdk": "^1.0.1-RC.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -20,7 +20,10 @@ export type RawOrder = OrderMetaData
  * Applies some transformations on the raw api data.
  * Some fields are kept as is.
  */
-export type Order = Pick<RawOrder, 'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature'> & {
+export type Order = Pick<
+  RawOrder,
+  'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature' | 'class'
+> & {
   receiver: string
   txHash?: string
   shortId: string

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -179,6 +179,8 @@ export function DetailsTable(props: Props): JSX.Element | null {
       label,
     })
 
+  const isFeeHidden = order.class === 'limit' && status !== 'filled'
+
   return (
     <Table
       body={
@@ -336,14 +338,16 @@ export function DetailsTable(props: Props): JSX.Element | null {
           </>
           {/*TODO: uncomment when fills tab is implemented */}
           {/*)}*/}
-          <tr>
-            <td>
-              <HelpTooltip tooltip={tooltip.fees} /> Fees
-            </td>
-            <td>
-              <GasFeeDisplay order={order} />
-            </td>
-          </tr>
+          {!isFeeHidden && (
+            <tr>
+              <td>
+                <HelpTooltip tooltip={tooltip.fees} /> Fees
+              </td>
+              <td>
+                <GasFeeDisplay order={order} />
+              </td>
+            </tr>
+          )}
           <tr>
             <td>
               <HelpTooltip tooltip={tooltip.appData} /> AppData

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,10 +1286,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^1.0.1-RC.0":
-  version "1.0.1-RC.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.0.tgz#3c0716581cd73ec909320df9267839e03b793155"
-  integrity sha512-1UKTJo7LmXp6Jm1l8CTd2blh8gIHear8/uD+KzGutXLp6YXDGc97oU88yfLNcPGN2OTEiq+tu/X3SvALCIwQ8w==
+"@cowprotocol/cow-sdk@^1.0.1-RC.2":
+  version "1.0.1-RC.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.2.tgz#ff47827679005e8b958b11c517a84c047497eae4"
+  integrity sha512-c0VFaSsz3/1W0X5//KFnO4qeWfD45Cj6UGO5kfQvmFcKMadQGYDDoQ+1o2QLzg4HHKc6BiamHvdx9ceJKQyrcA==
   dependencies:
     "@cowprotocol/app-data" "^0.0.1"
     "@cowprotocol/contracts" "^1.3.1"


### PR DESCRIPTION
# Summary

Closes [#1347](https://github.com/cowprotocol/cowswap/issues/1347)

Limit orders are created with fee=0 and we know the fee only after an order filling.
So, we should hide fee for limit orders while they are not filled.