### PR TITLE
Exclude executedSurplusFee from swappedAmountWithFee

### DIFF
--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -36,7 +36,6 @@ export function FilledProgress(props: Props): JSX.Element {
   const {
     order: {
       executedFeeAmount,
-      executedSurplusFee,
       filledAmount,
       filledPercentage,
       fullyFilled,
@@ -91,7 +90,7 @@ export function FilledProgress(props: Props): JSX.Element {
 
     // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
     filledAmountWithFee = filledAmount
-    swappedAmountWithFee = swappedAmount.plus(executedFeeAmount).plus(executedSurplusFee || 0)
+    swappedAmountWithFee = swappedAmount.plus(executedFeeAmount)
   }
 
   // In case the token object is empty, display the address


### PR DESCRIPTION
Fixes: https://github.com/cowprotocol/explorer/pull/267#pullrequestreview-1211388321

> Hey, I still can see a discrepancy between amount for Filled column for a [Buy ](https://pr267--explorer.review.gnosisdev.com/gc/orders/0xb371dc615c5dcc8da413e16a3110a2151a163707e09df0cb88755cb4ffaf66939fa3c00a92ec5f96b1ad2527ab41b3932efeda586391ffdc)Limit order:

![image](https://user-images.githubusercontent.com/7122625/206695932-ac5a5d10-07bf-44e7-add7-b4b0adc5d2c6.png)
