### PR TITLE
Remove surplus fees from what we swapped amount

### DIFF
--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -36,7 +36,6 @@ export function FilledProgress(props: Props): JSX.Element {
   const {
     order: {
       executedFeeAmount,
-      executedSurplusFee,
       filledAmount,
       filledPercentage,
       fullyFilled,
@@ -91,7 +90,7 @@ export function FilledProgress(props: Props): JSX.Element {
 
     // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
     filledAmountWithFee = filledAmount
-    swappedAmountWithFee = swappedAmount.plus(executedFeeAmount).plus(executedSurplusFee || 0)
+    swappedAmountWithFee = swappedAmount.plus(executedFeeAmount)
   }
 
   // In case the token object is empty, display the address


### PR DESCRIPTION
# Summary

Fixes issues describe here

https://github.com/cowprotocol/explorer/pull/267#issuecomment-1344346916



# To Test

1. Test with tx `0xb371dc615c5dcc8da413e16a3110a2151a163707e09df0cb88755cb4ffaf66939fa3c00a92ec5f96b1ad2527ab41b3932efeda586391ffdc`
2. Should show how the user payed `0.715205666982927037` 
3. Test also with a sell order. It should match too CowSwap, Explorer, and Etherscan

