### PR TITLE
Vercel setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 # Run on every commit
 on:
@@ -8,11 +8,13 @@ on:
   push:
     branches: [main, develop]
     tags: [v*]
+  workflow_dispatch: # Manually trigger it via UI/CLI/API
 
 env:
-  APP_ID: 1
   REPO_NAME_SLUG: explorer
   PR_NUMBER: ${{ github.event.number }}
+  NODE_VERSION: lts/gallium
+  APP_ID: 1
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   REACT_APP_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
@@ -28,11 +30,11 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Set output of cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache yarn cache
         uses: actions/cache@v2
@@ -67,7 +69,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Load dependencies
         id: cache-node-modules
@@ -98,7 +100,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Load dependencies
         id: cache-node-modules
@@ -132,7 +134,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Load dependencies
         id: cache-node-modules
@@ -200,7 +202,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
       - name: 'Production deployment: Upload release build files to be deployed'
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
   vercel-dev:
     # Deploys to Vercel dev environment
     name: Vercel dev
-    needs: [test, lint]
+    needs: [test]
     if: github.ref == 'refs/heads/develop'
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
@@ -135,7 +135,7 @@ jobs:
   vercel-pre-prod:
     # Deploys to Vercel staging and barn environments
     name: Vercel pre-prod
-    needs: [test, lint]
+    needs: [test]
     if: startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
@@ -148,7 +148,7 @@ jobs:
   vercel-prod:
     # Deploys to Vercel prod environment
     name: Vercel prod
-    needs: [test, lint]
+    needs: [test]
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/vercel.yml
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,39 @@ jobs:
           name: website
           path: dist
 
+  vercel-dev:
+    # Deploys to Vercel dev environment
+    name: Vercel dev
+    needs: [test, lint]
+    if: github.ref == 'refs/heads/develop'
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    with:
+      env_name: dev
+
+  vercel-pre-prod:
+    # Deploys to Vercel staging and barn environments
+    name: Vercel pre-prod
+    needs: [test, lint]
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    strategy:
+      matrix:
+        env_name: [barn, staging] # deploys both in parallel
+    with:
+      env_name: ${{ matrix.env_name }}
+
+  vercel-prod:
+    # Deploys to Vercel prod environment
+    name: Vercel prod
+    needs: [test, lint]
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    with:
+      env_name: prod
+
   storybook:
     name: Build storybook
     needs: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,17 +122,6 @@ jobs:
           name: website
           path: dist
 
-
-  vercel-test:
-    # TODO: remove!
-    # Test deployment for this PR only, remove before merging!
-    name: Vercel dev
-    needs: [test]
-    uses: ./.github/workflows/vercel.yml
-    secrets: inherit
-    with:
-      env_name: dev
-
   vercel-dev:
     # Deploys to Vercel dev environment
     name: Vercel dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,17 @@ jobs:
           name: website
           path: dist
 
+
+  vercel-test:
+    # TODO: remove!
+    # Test deployment for this PR only, remove before merging!
+    name: Vercel dev
+    needs: [test]
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    with:
+      env_name: dev
+
   vercel-dev:
     # Deploys to Vercel dev environment
     name: Vercel dev

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,0 +1,51 @@
+name: Vercel
+
+on:
+  workflow_call:
+    inputs:
+      env_name:
+        description: 'Environment to deploy to. Options are: dev, staging, barn and prod'
+        required: true
+        type: string
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env_name }} # Environment rules defined on GH UI
+    concurrency: ${{ inputs.env_name }} # Only one run per env at a time
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set VERCEL_PROJECT_ID env var
+        # It's set in each env's config on https://github.com/cowprotocol/cowswap/settings/environments
+        run: echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID }}" >> $GITHUB_ENV
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: >
+          REACT_APP_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+          REACT_APP_SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_ANALYTICS_ID }}
+          APP_ID=1
+          vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
+
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
+
+      - name: Deploy Project Artifacts to Vercel
+        run: >
+          vercel deploy --prebuilt --prod
+          -t ${{ secrets.VERCEL_TOKEN }}
+          -m VERSION=${{ steps.get_version.outputs.VERSION }}
+          -m COMMIT=${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ storybook-static
 tsconfig.tsbuildinfo
 playwright/build
 .idea/
+.vercel


### PR DESCRIPTION
# Summary

Setting up Vercel

This PR should have 2 Vercel builds
- 1 configured from the git integration, which will trigger the `Preview` build for every PR
- 1 `Production` build for `explorer-dev` env, forced only for testing. Should be removed before merging

# To Test

No functional changes to the code

1. Build should succeed
2. Vercel link should be added to PR
3. Test Production build should succeed (I'll add the link when it does) (it did! [build](https://github.com/cowprotocol/explorer/actions/runs/3856028098/jobs/6571778378) and the [deployed website](explorer-l1b5ly83v-cowswap.vercel.app) )