### PR TITLE
Hotfix 2.16.2 - Migrate to the high-availability RPC for Gnosis chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v1",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,

--- a/src/api/web3/index.ts
+++ b/src/api/web3/index.ts
@@ -90,7 +90,7 @@ export function getProviderByNetwork(networkId: Network | null): string | undefi
     case Network.GOERLI:
       return infuraProvider(networkId)
     case Network.GNOSIS_CHAIN:
-      return 'https://rpc.gnosischain.com/'
+      return 'https://rpc.gnosis.gateway.fm/'
     default:
       return undefined
   }

--- a/src/utils/walletconnectOptions.ts
+++ b/src/utils/walletconnectOptions.ts
@@ -13,7 +13,7 @@ export interface WCOptions {
 }
 
 const defaultRPC = {
-  [Network.GNOSIS_CHAIN]: 'https://rpc.gnosischain.com/',
+  [Network.GNOSIS_CHAIN]: 'https://rpc.gnosis.gateway.fm/',
 }
 
 export const setCustomWCOptions = (options: WCOptions): boolean => {


### PR DESCRIPTION
# Summary

The old (https://rpc.gnosischain.com/) Gnosis chain RPC endpoint is not stable and gets down sometimes.
Corresponding to https://docs.gnosischain.com/tools/rpc/#gateway we should https://rpc.gnosis.gateway.fm endpoint, because it provides a high-availability public RPC as part of their Core Contributor agreement in [GIP-70].

