### PR TITLE
Updated regexes for identifying current environment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,10 +19,11 @@ const EXPLORER_APP = {
   title: 'CoW Protocol Explorer',
   filename: 'index.html',
   envVars: {
-    EXPLORER_APP_DOMAIN_REGEX_DEV: '^protocol-explorer\\.dev|^localhost:\\d{2,5}|^pr\\d+--explorer\\.review',
-    EXPLORER_APP_DOMAIN_REGEX_STAGING: '^protocol-explorer\\.staging',
-    EXPLORER_APP_DOMAIN_REGEX_PROD: '^explorer\\.cow\\.fi|^gnosis-protocol\\.io',
-    EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.explorer\\.cow\\.fi|^barn\\.gnosis-protocol\\.io',
+    EXPLORER_APP_DOMAIN_REGEX_DEV:
+      '^dev\\.explorer\\.cow\\.fi|^(explorer-dev-git-[\\w\\d-]+|explorer-\\w{9}-)cowswap\\.vercel\\.app|^explorer-dev\\.vercel\\.app|^localhost:\\d{2,5}|^pr\\d+--explorer\\.review',
+    EXPLORER_APP_DOMAIN_REGEX_STAGING: '^staging\\.explorer\\.cow\\.fi|^explorer-staging\\.vercel\\.app',
+    EXPLORER_APP_DOMAIN_REGEX_PROD: '^explorer\\.cow\\.fi|^explorer-prod\\.vercel\\.app',
+    EXPLORER_APP_DOMAIN_REGEX_BARN: '^barn\\.explorer\\.cow\\.fi|^explorer-barn\\.vercel\\.app',
 
     OPERATOR_URL_STAGING_MAINNET: 'https://barn.api.cow.fi/mainnet/api',
     OPERATOR_URL_STAGING_GOERLI: 'https://barn.api.cow.fi/goerli/api',


### PR DESCRIPTION
# Summary

Updated regexes to make it aware of Vercel environments

# To Test

Manually tested the regexes against their expected URLs using https://regex101.com/

## dev
![Screenshot 2023-01-12 at 15 43 35](https://user-images.githubusercontent.com/43217/212114264-ccc5da1d-9c02-4eb9-9c31-b73d437bc6e8.png)

## staging
![Screenshot 2023-01-12 at 15 44 17](https://user-images.githubusercontent.com/43217/212114262-23c77e3b-39ff-4be1-8a8a-be348388b752.png)

## barn
![Screenshot 2023-01-12 at 15 47 49](https://user-images.githubusercontent.com/43217/212114256-0f63b80c-0ea7-46ba-b2fd-32098c3e22f1.png)

## prod
![Screenshot 2023-01-12 at 15 45 31](https://user-images.githubusercontent.com/43217/212114260-d3fb7955-4be0-4653-a883-bf798cb2f6f7.png)
