### PR TITLE
Updated dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,7 @@ updates:
   open-pull-requests-limit: 10
   target-branch: develop
   reviewers:
-  - w3stside
-  - anxolin
-  - alfetopito
+  - cowprotocol/frontend
   labels:
   - DEPENDABOT
   versioning-strategy: lockfile-only


### PR DESCRIPTION
# Summary

Since David left, dependabot was failing to tag people

https://github.com/cowprotocol/explorer/pull/326#issuecomment-1383393538

This change updates it to tag the whole team instead of individuals