### PR TITLE
[satsuma] Goerli test

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "0.0.1-RC.5",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^1.0.1-RC9",
+    "@cowprotocol/cow-sdk": "^1.0.1-RC.10",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "0.0.1-RC.5",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^1.0.1-RC.8",
+    "@cowprotocol/cow-sdk": "^1.0.1-RC9",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/src/const.ts
+++ b/src/const.ts
@@ -160,7 +160,11 @@ export const ORDER_BOOK_HOPS_MAX = 30
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
 export const LIMIT_EXCEEDED_ERROR_CODE = -32005
 
-export const COW_SDK = new CowSdk(Network.MAINNET)
+export const COW_SDK = new CowSdk(Network.MAINNET, {
+  subgraphBaseUrls: {
+    '5': 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
+  },
+})
 
 export const ETH: TokenErc20 = {
   name: 'ETH',

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import BN from 'bn.js'
-import { CowSdk } from '@cowprotocol/cow-sdk'
+import { CowSdk, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { TokenErc20, UNLIMITED_ORDER_AMOUNT, BATCH_TIME } from '@gnosis.pm/dex-js'
 export {
   UNLIMITED_ORDER_AMOUNT,
@@ -162,7 +162,7 @@ export const LIMIT_EXCEEDED_ERROR_CODE = -32005
 
 export const COW_SDK = new CowSdk(Network.MAINNET, {
   subgraphBaseUrls: {
-    '5': 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
+    [ChainId.GOERLI]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
   },
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,10 +1369,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^1.0.1-RC.8":
-  version "1.0.1-RC.8"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.8.tgz#91fc8765554e3976dcbec2135c9cdfb041bfe34d"
-  integrity sha512-kNzIeuhTOiRI6mVbHiS4PtEMMeTzgIOzLsI0VLtDQpqY8bRXqyaahs8xJLEISnX36gpPM4LZ2p+d5y76ZznCPQ==
+"@cowprotocol/cow-sdk@^1.0.1-RC9":
+  version "1.0.1-RC9"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC9.tgz#6010f0016bf197a1c1ef0514540016c779bae3ec"
+  integrity sha512-he3S/trLKLXC0hi4Gmm/ZDFjO9aHoAZWK64fuQIn4zF66oFoNs804n6/0vPhdCvIyJnvW+49h5FXwOHYDARaJA==
   dependencies:
     "@cowprotocol/app-data" "^0.0.2-RC.1"
     "@cowprotocol/contracts" "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,10 +1369,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^1.0.1-RC9":
-  version "1.0.1-RC9"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC9.tgz#6010f0016bf197a1c1ef0514540016c779bae3ec"
-  integrity sha512-he3S/trLKLXC0hi4Gmm/ZDFjO9aHoAZWK64fuQIn4zF66oFoNs804n6/0vPhdCvIyJnvW+49h5FXwOHYDARaJA==
+"@cowprotocol/cow-sdk@^1.0.1-RC.10":
+  version "1.0.1-RC.10"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.10.tgz#d5b6cbe1db07d8075d7d4431c12d3986dd940d41"
+  integrity sha512-DWpzgT+tTiWjwuLlapWTF5gGQSSBW1nJ3vp0glhwWSxgOwaZRUyBUrZj1PAP1/pHKnjooArKt/wq2HeignjRYw==
   dependencies:
     "@cowprotocol/app-data" "^0.0.2-RC.1"
     "@cowprotocol/contracts" "^1.3.1"


### PR DESCRIPTION
# Summary

Updates the SDK to a version that allows to set your own Subgraph.

It adds Satsuma replacement for the Subgraph in Goerli

# To Test

- The charts should work for Goerli (no other network needs to be tested thoroughly)