### PR TITLE
Add envs to configure the Subgraph URLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "0.0.1-RC.5",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^1.0.1-RC9",
+    "@cowprotocol/cow-sdk": "^1.0.1-RC.10",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "0.0.1-RC.5",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^1.0.1-RC.8",
+    "@cowprotocol/cow-sdk": "^1.0.1-RC9",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "0.0.1-RC.5",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^1.0.1-RC.10",
+    "@cowprotocol/cow-sdk": "^1.0.2-RC.7",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/src/const.ts
+++ b/src/const.ts
@@ -160,12 +160,29 @@ export const ORDER_BOOK_HOPS_MAX = 30
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
 export const LIMIT_EXCEEDED_ERROR_CODE = -32005
 
+function getSubgraphUrls(): Partial<Record<ChainId, string>> {
+  const subgraphBaseUrls: Partial<Record<ChainId, string>> = {}
+  const [mainnetUrl, gcUrl, goerliUrl] = [
+    process.env.REACT_APP_SUBGRAPH_URL_MAINNET || undefined,
+    process.env.REACT_APP_SUBGRAPH_URL_GNOSIS_CHAIN || undefined,
+    process.env.REACT_APP_SUBGRAPH_URL_GOERLI || undefined,
+  ]
+
+  if (mainnetUrl) {
+    subgraphBaseUrls[ChainId.MAINNET] = mainnetUrl
+  }
+  if (gcUrl) {
+    subgraphBaseUrls[ChainId.GNOSIS_CHAIN] = gcUrl
+  }
+  if (goerliUrl) {
+    subgraphBaseUrls[ChainId.GOERLI] = goerliUrl
+  }
+
+  return subgraphBaseUrls
+}
+
 export const COW_SDK = new CowSdk(Network.MAINNET, {
-  subgraphBaseUrls: {
-    [ChainId.MAINNET]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow/api',
-    [ChainId.GOERLI]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
-    [ChainId.GNOSIS_CHAIN]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-gc/api',
-  },
+  subgraphBaseUrls: getSubgraphUrls(),
 })
 
 export const ETH: TokenErc20 = {

--- a/src/const.ts
+++ b/src/const.ts
@@ -160,7 +160,11 @@ export const ORDER_BOOK_HOPS_MAX = 30
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
 export const LIMIT_EXCEEDED_ERROR_CODE = -32005
 
-export const COW_SDK = new CowSdk(Network.MAINNET)
+export const COW_SDK = new CowSdk(Network.MAINNET, {
+  subgraphBaseUrls: {
+    '5': 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
+  },
+})
 
 export const ETH: TokenErc20 = {
   name: 'ETH',

--- a/src/const.ts
+++ b/src/const.ts
@@ -162,7 +162,9 @@ export const LIMIT_EXCEEDED_ERROR_CODE = -32005
 
 export const COW_SDK = new CowSdk(Network.MAINNET, {
   subgraphBaseUrls: {
+    [ChainId.MAINNET]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow/api',
     [ChainId.GOERLI]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
+    [ChainId.GNOSIS_CHAIN]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-gc/api',
   },
 })
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import BN from 'bn.js'
-import { CowSdk } from '@cowprotocol/cow-sdk'
+import { CowSdk, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { TokenErc20, UNLIMITED_ORDER_AMOUNT, BATCH_TIME } from '@gnosis.pm/dex-js'
 export {
   UNLIMITED_ORDER_AMOUNT,
@@ -162,7 +162,7 @@ export const LIMIT_EXCEEDED_ERROR_CODE = -32005
 
 export const COW_SDK = new CowSdk(Network.MAINNET, {
   subgraphBaseUrls: {
-    '5': 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
+    [ChainId.GOERLI]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
   },
 })
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,10 @@ const EXPLORER_APP = {
 
     GOOGLE_ANALYTICS_ID: undefined,
     REACT_APP_SENTRY_DSN: undefined,
+
+    REACT_APP_SUBGRAPH_URL_MAINNET: undefined,
+    REACT_APP_SUBGRAPH_URL_GNOSIS_CHAIN: undefined,
+    REACT_APP_SUBGRAPH_URL_GOERLI: undefined,
   },
 }
 const ALL_APPS = [EXPLORER_APP]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,10 +1357,10 @@
   dependencies:
     ajv "^8.11.0"
 
-"@cowprotocol/app-data@^0.0.2-RC.1":
-  version "0.0.2-RC.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.2-RC.1.tgz#66f02f05e120b4b03b265fd609c07089f0db68c9"
-  integrity sha512-x+fRnQ62u9nF04vkeWoiiU97Ug6kPunn76uZeVF1TyVg7N8TAy97XJL7V5s9PKddbmT5TKECmVqQ0TVeeyCtDA==
+"@cowprotocol/app-data@^0.0.3-RC.0":
+  version "0.0.3-RC.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.3-RC.0.tgz#23fc1e19adade3e95243f03e9624f42e6ae165c6"
+  integrity sha512-N1JpAIK9cTGnmI/Z682GtEN7LJYzc96klqHZMR58mqlsoZVobPpH9x7QDug03hTjE+81N0J7NwdiQ7y3lhKvoQ==
   dependencies:
     ajv "^8.11.0"
 
@@ -1369,12 +1369,12 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^1.0.1-RC.10":
-  version "1.0.1-RC.10"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.10.tgz#d5b6cbe1db07d8075d7d4431c12d3986dd940d41"
-  integrity sha512-DWpzgT+tTiWjwuLlapWTF5gGQSSBW1nJ3vp0glhwWSxgOwaZRUyBUrZj1PAP1/pHKnjooArKt/wq2HeignjRYw==
+"@cowprotocol/cow-sdk@^1.0.2-RC.7":
+  version "1.0.2-RC.7"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.2-RC.7.tgz#8198e490d710210bed73eb281b81d6b3b034a20b"
+  integrity sha512-Op9I+EBiQYbQJINIA+t5GjSK30Qyecjh9/P5n0a4qKwsJQOVedq66s8w8GLmCfUQI/m7ys/73n8dSa9Z4H4zcA==
   dependencies:
-    "@cowprotocol/app-data" "^0.0.2-RC.1"
+    "@cowprotocol/app-data" "^0.0.3-RC.0"
     "@cowprotocol/contracts" "^1.3.1"
     cross-fetch "^3.1.5"
     ethers "^5.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,10 +1369,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^1.0.1-RC.8":
-  version "1.0.1-RC.8"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.8.tgz#91fc8765554e3976dcbec2135c9cdfb041bfe34d"
-  integrity sha512-kNzIeuhTOiRI6mVbHiS4PtEMMeTzgIOzLsI0VLtDQpqY8bRXqyaahs8xJLEISnX36gpPM4LZ2p+d5y76ZznCPQ==
+"@cowprotocol/cow-sdk@^1.0.1-RC9":
+  version "1.0.1-RC9"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC9.tgz#6010f0016bf197a1c1ef0514540016c779bae3ec"
+  integrity sha512-he3S/trLKLXC0hi4Gmm/ZDFjO9aHoAZWK64fuQIn4zF66oFoNs804n6/0vPhdCvIyJnvW+49h5FXwOHYDARaJA==
   dependencies:
     "@cowprotocol/app-data" "^0.0.2-RC.1"
     "@cowprotocol/contracts" "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,10 +1369,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
   integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
 
-"@cowprotocol/cow-sdk@^1.0.1-RC9":
-  version "1.0.1-RC9"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC9.tgz#6010f0016bf197a1c1ef0514540016c779bae3ec"
-  integrity sha512-he3S/trLKLXC0hi4Gmm/ZDFjO9aHoAZWK64fuQIn4zF66oFoNs804n6/0vPhdCvIyJnvW+49h5FXwOHYDARaJA==
+"@cowprotocol/cow-sdk@^1.0.1-RC.10":
+  version "1.0.1-RC.10"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.1-RC.10.tgz#d5b6cbe1db07d8075d7d4431c12d3986dd940d41"
+  integrity sha512-DWpzgT+tTiWjwuLlapWTF5gGQSSBW1nJ3vp0glhwWSxgOwaZRUyBUrZj1PAP1/pHKnjooArKt/wq2HeignjRYw==
   dependencies:
     "@cowprotocol/app-data" "^0.0.2-RC.1"
     "@cowprotocol/contracts" "^1.3.1"


### PR DESCRIPTION
# Summary

This PR allows to configure the Explorer with any other subgraph API URL. 

It will default to the SDK default one (currently The Graph hosted service). 


For example 

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/2352112/221820110-1dfd430b-bc4e-40aa-b2da-919105ce66a2.png">


The idea is to allow to test Satsuma in production, and easily revert the version.

# To Test

1. Verify all the calls are done to satsuma in the network tab (dev tools)
2. Make sure the app works as before
