### PR TITLE
Using a custom node version on vercel build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
     secrets: inherit
     with:
       env_name: dev
+      node_version: ${{ env.NODE_VERSION }}
 
   vercel-pre-prod:
     # Deploys to Vercel staging and barn environments
@@ -94,6 +95,7 @@ jobs:
         env_name: [barn, staging] # deploys both in parallel
     with:
       env_name: ${{ matrix.env_name }}
+      node_version: ${{ env.NODE_VERSION }}
 
   vercel-prod:
     # Deploys to Vercel prod environment
@@ -104,3 +106,4 @@ jobs:
     secrets: inherit
     with:
       env_name: prod
+      node_version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -7,6 +7,9 @@ on:
         description: 'Environment to deploy to. Options are: dev, staging, barn and prod'
         required: true
         type: string
+      node_version:
+        required: true
+        type: string
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -20,6 +23,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: yarn
 
       - name: Set VERCEL_PROJECT_ID env var
         # It's set in each env's config on https://github.com/cowprotocol/explorer/settings/environments


### PR DESCRIPTION
# Summary

Fixes vercel build https://github.com/cowprotocol/explorer/actions/runs/4293564849/jobs/7481491163

Default node version on `ubuntu-latest` runners have been recently upgraded from 16 to 18. See https://github.com/actions/runner-images/commit/ce2e896fcb377ad12c28dab237bc69630732b8fd

The vercel build did not have a custom version pinned.
Thus, the upstream change broke it.

This PR pins the vercel workflow to the same node version as the parent workflow

# To Test

Nothing to be tested.
Need to merge this to develop and observe the development build action

