### PR TITLE
Passing new subgraph envvars to vercel build

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -43,6 +43,9 @@ jobs:
           REACT_APP_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
           REACT_APP_SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
           GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_ANALYTICS_ID }}
+          REACT_APP_SUBGRAPH_URL_MAINNET=${{ secrets.REACT_APP_SUBGRAPH_URL_MAINNET }}
+          REACT_APP_SUBGRAPH_URL_GNOSIS_CHAIN=${{ secrets.REACT_APP_SUBGRAPH_URL_GNOSIS_CHAIN }}
+          REACT_APP_SUBGRAPH_URL_GOERLI=${{ secrets.REACT_APP_SUBGRAPH_URL_GOERLI }}
           APP_ID=1
           vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
 


### PR DESCRIPTION
# Summary

Passing new subgraph envvars to vercel build

Env vars have already being added to GH settings to all environments

<img width="678" alt="Screenshot 2023-02-28 at 15 29 38" src="https://user-images.githubusercontent.com/43217/221902735-4556703a-38e8-49f9-a184-68f7fc7677ea.png">

# Testing

Once merged and deployed onto develop, check whether the graph requests are going to satsuma