### PR TITLE
Disabled search term being shown temporarily

### DIFF
--- a/src/components/orders/OrderNotFound/index.tsx
+++ b/src/components/orders/OrderNotFound/index.tsx
@@ -108,10 +108,11 @@ export const OrderAddressNotFound: React.FC = (): JSX.Element => {
       <Content>
         {searchString ? (
           <>
-            <p>Sorry, no matches found for:</p>
-            <p>
+            <p>Sorry, no matches found.</p>
+            {/* Disabled temporarily, until we can implement a way to validate search strings. */}
+            {/*<p>
               <strong>&quot;{searchString}&quot;</strong>
-            </p>
+            </p>*/}
           </>
         ) : (
           <p>The search cannot be empty</p>


### PR DESCRIPTION
# Summary

Due to a recent report, we have disabled the search term from being shown to the user as a temporary fix.

![Screenshot 2023-03-03 at 11 09 24](https://user-images.githubusercontent.com/5172699/222692924-e9dba593-8326-4a9b-b9b0-5ed3645ca9d4.png)

# To Test

1. Go to explorer
2. Enter a search term like "givememoneyplease"
3. Press enter
4. You should not see it being shown back to you.

# Background

We are discussing what can be done here, but at the very least, we'll need a validator for the search term before we can show this again.