### PR TITLE
Handle error when Barn is down

### DIFF
--- a/src/cowSdk.ts
+++ b/src/cowSdk.ts
@@ -18,7 +18,6 @@ function getSubgraphUrls(): Record<SupportedChainId, string> {
   }
 }
 
-export const prodOrderBookSDK = new OrderBookApi({ env: 'prod' })
-export const stagingOrderBookSDK = new OrderBookApi({ env: 'staging' })
+export const orderBookSDK = new OrderBookApi({ env: 'prod' })
 export const subgraphApiSDK = new SubgraphApi(undefined, getSubgraphUrls())
 export const metadataApiSDK = new MetadataApi()


### PR DESCRIPTION
# Summary
This PR adds some resilience in case BARN is down (which is more fragile and less important than PROD)

In case Barn is down, it will just show PROD data.

## Context
https://cowservices.slack.com/archives/C0361CDD1FZ/p1680083877919069?thread_ts=1680081047.924569&cid=C0361CDD1FZ

## Technical comment
I took the opportunity of this change to not use 2 SDKs, only one is needed (since we can pass the environment each time)

# To Test

**TEST BOTH BARN & PROD orders/trades are displayed in the explorer.

We cannot make it fail right now to test it work, so i will just make another PR making BARN to fail on porpouse to verify that it still shows the PROD data