### PR TITLE
Style fixes for  Order fills page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[{*.ts,*.tsx}]
+ij_typescript_force_quote_style = true
+ij_typescript_use_double_quotes = false
+ij_typescript_use_semicolon_after_statement = false

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -66,7 +66,7 @@ export type Trade = Pick<RawTrade, 'blockNumber' | 'logIndex' | 'owner' | 'txHas
   buyTokenAddress: string
   sellToken?: TokenErc20 | null
   sellTokenAddress: string
-  executionTime: Date
+  executionTime: Date | null
   surplusAmount?: BigNumber
   surplusPercentage?: BigNumber
 }

--- a/src/apps/explorer/styled.ts
+++ b/src/apps/explorer/styled.ts
@@ -63,6 +63,7 @@ export const MainWrapper = styled.div`
     flex-direction: column;
     flex-grow: 1;
     justify-content: space-between;
+    width: 100%;
   }
   footer {
     flex-direction: row;

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -29,6 +29,12 @@ const Wrapper = styled.div`
   > span > b {
     font-weight: ${({ theme }): string => theme.fontMedium};
   }
+
+  > div {
+    ${media.mobile} {
+      max-width: 150px;
+    }
+  }
 `
 
 const TableHeading = styled.div`

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -114,45 +114,19 @@ export function FilledProgress(props: Props): JSX.Element {
   } = props
 
   const touched = filledPercentage.gt(0)
+  const isSell = kind === 'sell'
 
-  let mainToken
-  let mainAddress
-  let mainAmount
-  let swappedToken
-  let swappedAddress
-  let swappedAmount
-  let action: string | null | undefined
-
-  let filledAmountWithFee, swappedAmountWithFee
-  if (kind === 'sell') {
-    action = 'sold'
-
-    mainToken = sellToken
-    mainAddress = sellTokenAddress
-    mainAmount = sellAmount.plus(feeAmount)
-
-    swappedToken = buyToken
-    swappedAddress = buyTokenAddress
-    swappedAmount = executedBuyAmount
-
-    // Sell orders, add the fee in to the sellAmount (mainAmount, in this case)
-    filledAmountWithFee = filledAmount.plus(executedFeeAmount)
-    swappedAmountWithFee = swappedAmount
-  } else {
-    action = 'bought'
-
-    mainToken = buyToken
-    mainAddress = buyTokenAddress
-    mainAmount = buyAmount
-
-    swappedToken = sellToken
-    swappedAddress = sellTokenAddress
-    swappedAmount = executedSellAmount
-
-    // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
-    filledAmountWithFee = filledAmount
-    swappedAmountWithFee = swappedAmount.plus(executedFeeAmount)
-  }
+  const mainToken = isSell ? sellToken : buyToken
+  const mainAddress = isSell ? sellTokenAddress : buyTokenAddress
+  const mainAmount = isSell ? sellAmount.plus(feeAmount) : buyAmount
+  const swappedToken = isSell ? buyToken : sellToken
+  const swappedAddress = isSell ? buyTokenAddress : sellTokenAddress
+  const swappedAmount = isSell ? executedBuyAmount : executedSellAmount
+  const action = isSell ? 'sold' : 'bought'
+  // Sell orders, add the fee in to the sellAmount (mainAmount, in this case)
+  // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
+  const filledAmountWithFee = isSell ? filledAmount.plus(executedFeeAmount) : filledAmount
+  const swappedAmountWithFee = isSell ? swappedAmount : swappedAmount.plus(executedFeeAmount)
 
   // In case the token object is empty, display the address
   const mainSymbol = mainToken ? safeTokenName(mainToken) : mainAddress

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -43,18 +43,22 @@ const TableHeading = styled.div`
   padding: 1.6rem;
   display: flex;
   gap: 2rem;
+
   ${media.mobile} {
     flex-direction: column;
     gap: 1rem;
   }
+
   .title {
     text-transform: uppercase;
     font-size: 1.1rem;
   }
+
   .fillNumber {
     font-size: 3.2rem;
     margin: 1.5rem 0 1rem 0;
     color: ${({ theme }): string => theme.green};
+
     ${media.mobile} {
       font-size: 2.8rem;
     }
@@ -63,9 +67,11 @@ const TableHeading = styled.div`
   .priceNumber {
     font-size: 2.2rem;
     margin: 1rem 0;
+
     ${media.mobile} {
       font-size: 1.8rem;
     }
+
     span {
       line-height: 1;
     }
@@ -77,12 +83,15 @@ const TableHeadingContent = styled.div`
   flex-direction: column;
   justify-content: center;
   width: 27rem;
+
   ${media.mobile} {
     flex-direction: column;
   }
+
   .progress-line {
     width: 100%;
   }
+
   &.limit-price {
     width: 38rem;
   }
@@ -147,14 +156,14 @@ export function FilledProgress(props: Props): JSX.Element {
       <OrderAssetsInfoWrapper>
         <b>
           {/* Executed part (bought/sold tokens) */}
-          <TokenAmount amount={filledAmountWithFee} token={mainToken} symbol={mainSymbol}/>
+          <TokenAmount amount={filledAmountWithFee} token={mainToken} symbol={mainSymbol} />
         </b>{' '}
         {!fullyFilled && (
           // Show the total amount to buy/sell. Only for orders that are not 100% executed
           <>
             of{' '}
             <b>
-              <TokenAmount amount={mainAmount} token={mainToken} symbol={mainSymbol}/>
+              <TokenAmount amount={mainAmount} token={mainToken} symbol={mainSymbol} />
             </b>{' '}
           </>
         )}
@@ -166,7 +175,7 @@ export function FilledProgress(props: Props): JSX.Element {
           <>
             for a total of{' '}
             <b>
-              <TokenAmount amount={swappedAmountWithFee} token={swappedToken} symbol={swappedSymbol}/>
+              <TokenAmount amount={swappedAmountWithFee} token={swappedToken} symbol={swappedSymbol} />
             </b>
           </>
         )}

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -1,16 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
-
 import { media } from 'theme/styles/media'
-
 import { Order } from 'api/operator'
-
-import { FormatAmountPrecision, formatSmartMaxPrecision, formattingAmountPrecision, safeTokenName } from 'utils'
-
+import { safeTokenName } from 'utils'
 import { ProgressBar } from 'components/common/ProgressBar'
 import { OrderPriceDisplay } from '../OrderPriceDisplay'
-import BigNumber from "bignumber.js";
-import { TokenErc20 } from "@gnosis.pm/dex-js";
+import { TokenAmount } from 'components/token/TokenAmount'
 
 export type Props = {
   order: Order
@@ -98,14 +93,6 @@ const OrderAssetsInfoWrapper = styled.span`
   font-size: 12px;
   line-height: normal;
 `
-
-// TODO: unify with TokenAmount in @cowprotocol/cowswap
-function TokenAmount({amount, token, symbol}: {amount: BigNumber, symbol: string, token?: TokenErc20 | null}) {
-  const fullAmount = formatSmartMaxPrecision(amount, token)
-  const displayedAmount = formattingAmountPrecision(amount, token, FormatAmountPrecision.highPrecision)
-
-  return <span title={fullAmount + ' ' + symbol}>{displayedAmount} {symbol}</span>
-}
 
 export function FilledProgress(props: Props): JSX.Element {
   const {

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faExchangeAlt, faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
@@ -24,6 +24,7 @@ import Icon from 'components/Icon'
 import { calculatePrice, TokenErc20 } from '@gnosis.pm/dex-js'
 import { TEN_BIG_NUMBER } from 'const'
 import BigNumber from 'bignumber.js'
+import ShimmerBar from 'apps/explorer/components/common/ShimmerBar'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead {
@@ -31,13 +32,17 @@ const Wrapper = styled(StyledUserDetailsTable)`
       padding: 0 2rem;
     }
   }
+
   > tbody {
     min-height: 37rem;
     border-bottom: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
+
     > tr {
       min-height: 7.4rem;
+
       &.header-row {
         display: none;
+
         ${media.mobile} {
           display: flex;
           background: transparent;
@@ -46,10 +51,12 @@ const Wrapper = styled(StyledUserDetailsTable)`
           margin: 0;
           box-shadow: none;
           min-height: 2rem;
+
           td {
             padding: 0;
             margin: 0;
             margin-top: 1rem;
+
             .mobile-header {
               margin: 0;
             }
@@ -57,35 +64,43 @@ const Wrapper = styled(StyledUserDetailsTable)`
         }
       }
     }
+
     > tr > td:first-child {
       padding: 0 2rem;
     }
   }
+
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 4fr 2fr 3fr 3fr 3fr 4fr 4fr;
+    grid-template-columns: 4fr 2fr 3fr 3fr 3.5fr 3fr 4fr;
   }
+
   > tbody > tr > td:nth-child(8),
   > thead > tr > th:nth-child(8) {
     justify-content: center;
   }
+
   tr > td {
     span.span-inside-tooltip {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
+
       img {
         padding: 0;
       }
     }
   }
+
   ${media.mobile} {
     > thead > tr {
       display: none;
+
       > th:first-child {
         padding: 0 1rem;
       }
     }
+
     > tbody > tr {
       grid-template-columns: none;
       border: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
@@ -93,14 +108,17 @@ const Wrapper = styled(StyledUserDetailsTable)`
       border-radius: 6px;
       margin-top: 10px;
       padding: 12px;
+
       &:hover {
         background: none;
         backdrop-filter: none;
       }
+
       td:first-child {
         padding: 0 1rem;
       }
     }
+
     tr > td {
       display: flex;
       flex: 1;
@@ -109,14 +127,17 @@ const Wrapper = styled(StyledUserDetailsTable)`
       margin: 0;
       margin-bottom: 18px;
       min-height: 32px;
+
       span.span-inside-tooltip {
         align-items: flex-end;
         flex-direction: column;
+
         img {
           margin-left: 0;
         }
       }
     }
+
     > tbody > tr > td,
     > thead > tr > th {
       :nth-child(4),
@@ -127,32 +148,39 @@ const Wrapper = styled(StyledUserDetailsTable)`
         justify-content: space-between;
       }
     }
+
     .header-value {
       flex-wrap: wrap;
       text-align: end;
     }
+
     .span-copybtn-wrap {
       display: flex;
       flex-wrap: nowrap;
+
       span {
         display: flex;
         align-items: center;
       }
+
       .copy-text {
         display: none;
       }
     }
   }
+
   overflow: auto;
 `
 
 const HeaderTitle = styled.span`
   display: none;
+
   ${media.mobile} {
     font-weight: 600;
     align-items: center;
     display: flex;
     margin-right: 3rem;
+
     svg {
       margin-left: 5px;
     }
@@ -160,6 +188,7 @@ const HeaderTitle = styled.span`
 `
 const HeaderValue = styled.span<{ captionColor?: 'green' | 'red1' | 'grey' }>`
   color: ${({ theme, captionColor }): string => (captionColor ? theme[captionColor] : theme.textPrimary1)};
+
   ${media.mobile} {
     flex-wrap: wrap;
     text-align: end;
@@ -182,6 +211,11 @@ const StyledLinkButton = styled(LinkButton)`
   }
 `
 
+const StyledShimmerBar = styled(ShimmerBar)`
+  min-height: 20px;
+  min-width: 100px;
+`
+
 export type Props = StyledUserDetailsTableProps & {
   trades: Trade[] | undefined
   order: Order | null
@@ -200,7 +234,7 @@ function calculateExecutionPrice(
   sellAmount: BigNumber,
   buyAmount: BigNumber,
   sellToken?: TokenErc20 | null,
-  buyToken?: TokenErc20 | null
+  buyToken?: TokenErc20 | null,
 ): BigNumber | null {
   if (!sellToken || !buyToken) return null
 
@@ -210,9 +244,7 @@ function calculateExecutionPrice(
   return calculatePrice({
     numerator: isPriceInverted ? buyData : sellData,
     denominator: isPriceInverted ? sellData : buyData,
-  }).multipliedBy(
-    TEN_BIG_NUMBER.exponentiatedBy((isPriceInverted ? buyToken : sellToken).decimals)
-  )
+  }).multipliedBy(TEN_BIG_NUMBER.exponentiatedBy((isPriceInverted ? buyToken : sellToken).decimals))
 }
 
 const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) => {
@@ -225,8 +257,6 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) =
   const buyToken = tokens[buyTokenAddress]
   const sellToken = tokens[sellTokenAddress]
 
-  const executionTimeFormatted =
-    executionTime instanceof Date && !isNaN(Date.parse(executionTime.toString())) ? executionTime : new Date()
   const executionPrice = calculateExecutionPrice(isPriceInverted, sellAmount, buyAmount, sellToken, buyToken)
   const executionToken = isPriceInverted ? buyToken : sellToken
 
@@ -256,24 +286,24 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) =
       <td>
         <HeaderTitle>Buy amount</HeaderTitle>
         <HeaderValue>
-          <TokenAmount amount={buyAmount} token={buyToken}/>
+          <TokenAmount amount={buyAmount} token={buyToken} />
         </HeaderValue>
       </td>
       <td>
         <HeaderTitle>Sell amount</HeaderTitle>
         <HeaderValue>
-          <TokenAmount amount={sellAmount} token={sellToken}/>
+          <TokenAmount amount={sellAmount} token={sellToken} />
         </HeaderValue>
       </td>
       <td>
         <HeaderTitle>Execution price {invertButton}</HeaderTitle>
-        <HeaderValue>
-            {executionPrice && <TokenAmount amount={executionPrice} token={executionToken}/>}
-        </HeaderValue>
+        <HeaderValue>{executionPrice && <TokenAmount amount={executionPrice} token={executionToken} />}</HeaderValue>
       </td>
       <td>
         <HeaderTitle>Execution time</HeaderTitle>
-        <HeaderValue>{<DateDisplay date={executionTimeFormatted} showIcon={true} />}</HeaderValue>
+        <HeaderValue>
+          {executionTime ? <DateDisplay date={executionTime} showIcon={true} /> : <StyledShimmerBar />}
+        </HeaderValue>
       </td>
       <td>
         <HeaderTitle></HeaderTitle>
@@ -292,7 +322,11 @@ const FillsTable: React.FC<Props> = (props) => {
   const { trades, order, tableState, showBorderTable = false } = props
   const [isPriceInverted, setIsPriceInverted] = useState(false)
 
-  const invertButton = <Icon icon={faExchangeAlt} onClick={() => setIsPriceInverted(value => !value)} />
+  const onInvert = useCallback(() => {
+    setIsPriceInverted((value) => !value)
+  }, [])
+
+  const invertButton = <Icon icon={faExchangeAlt} onClick={onInvert} />
 
   const tradeItems = (items: Trade[] | undefined): JSX.Element => {
     if (!items || items.length === 0) {
@@ -306,7 +340,7 @@ const FillsTable: React.FC<Props> = (props) => {
         </tr>
       )
     } else {
-        return (
+      return (
         <>
           {items.map((item, i) => (
             <RowFill
@@ -314,7 +348,8 @@ const FillsTable: React.FC<Props> = (props) => {
               index={i + tableState.pageOffset}
               trade={item}
               invertButton={invertButton}
-              isPriceInverted={isPriceInverted} />
+              isPriceInverted={isPriceInverted}
+            />
           ))}
         </>
       )

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -196,7 +196,7 @@ interface RowProps {
 }
 
 function calculateExecutionPrice(
-  isPriceInversed: boolean,
+  isPriceInverted: boolean,
   sellAmount: BigNumber,
   buyAmount: BigNumber,
   sellToken?: TokenErc20 | null,
@@ -208,10 +208,10 @@ function calculateExecutionPrice(
   const buyData = { amount: buyAmount, decimals: buyToken.decimals }
 
   return calculatePrice({
-    numerator: isPriceInversed ? buyData : sellData,
-    denominator: isPriceInversed ? sellData : buyData,
+    numerator: isPriceInverted ? buyData : sellData,
+    denominator: isPriceInverted ? sellData : buyData,
   }).multipliedBy(
-    TEN_BIG_NUMBER.exponentiatedBy((isPriceInversed ? buyToken : sellToken).decimals)
+    TEN_BIG_NUMBER.exponentiatedBy((isPriceInverted ? buyToken : sellToken).decimals)
   )
 }
 

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
 import { useNetworkId } from 'state/network'
 import { Order, Trade } from 'api/operator'
-import { abbreviateString, formatSmartMaxPrecision } from 'utils'
+import { abbreviateString } from 'utils'
 import { useMultipleErc20 } from 'hooks/useErc20'
 
 import StyledUserDetailsTable, {
@@ -19,6 +19,7 @@ import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import { TableState } from 'apps/explorer/components/TokensTableWidget/useTable'
 import { LinkButton } from '../DetailsTable'
 import { FilledProgress } from '../FilledProgress'
+import { TokenAmount } from 'components/token/TokenAmount'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead {
@@ -58,7 +59,7 @@ const Wrapper = styled(StyledUserDetailsTable)`
   }
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 4fr 2fr 2fr 3fr 3fr 4fr 4fr;
+    grid-template-columns: 4fr 2fr 3fr 3fr 3fr 4fr 4fr;
   }
   > tbody > tr > td:nth-child(8),
   > thead > tr > th:nth-child(8) {
@@ -164,6 +165,17 @@ const HeaderValue = styled.span<{ captionColor?: 'green' | 'red1' | 'grey' }>`
 const MainWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
+`
+
+const StyledLinkButton = styled(LinkButton)`
+  margin-left: 0;
+
+  ${media.mediumDown} {
+    min-width: auto;
+    font-size: 12px;
+    padding: 4px 8px;
+  }
 `
 
 export type Props = StyledUserDetailsTableProps & {
@@ -188,13 +200,6 @@ const RowFill: React.FC<RowProps> = ({ trade }) => {
   const sellToken = tokens[sellTokenAddress]
   const executionTimeFormatted =
     executionTime instanceof Date && !isNaN(Date.parse(executionTime.toString())) ? executionTime : new Date()
-
-  const buyFormattedAmount =
-    buyToken && buyToken.decimals >= 0
-      ? formatSmartMaxPrecision(buyAmount, tokens[buyTokenAddress])
-      : sellAmount.toString(10)
-  const sellFormattedAmount =
-    sellToken && sellToken.decimals >= 0 ? formatSmartMaxPrecision(sellAmount, sellToken) : sellAmount.toString(10)
 
   if (!network || !txHash) {
     return null
@@ -222,19 +227,20 @@ const RowFill: React.FC<RowProps> = ({ trade }) => {
       <td>
         <HeaderTitle>Buy amount</HeaderTitle>
         <HeaderValue>
-          {buyFormattedAmount} {buyToken?.symbol}
+          <TokenAmount amount={buyAmount} token={buyToken}/>
         </HeaderValue>
       </td>
       <td>
         <HeaderTitle>Sell amount</HeaderTitle>
         <HeaderValue>
-          {sellFormattedAmount} {sellToken?.symbol}
+          <TokenAmount amount={sellAmount} token={sellToken}/>
         </HeaderValue>
       </td>
       <td>
+          {/*TODO: I'm not sure that it's a proper value of execution price*/}
         <HeaderTitle>Execution price</HeaderTitle>
         <HeaderValue>
-          {sellFormattedAmount} {sellToken?.symbol}
+          <TokenAmount amount={sellAmount} token={sellToken}/>
         </HeaderValue>
       </td>
       <td>
@@ -244,10 +250,10 @@ const RowFill: React.FC<RowProps> = ({ trade }) => {
       <td>
         <HeaderTitle></HeaderTitle>
         <HeaderValue>
-          <LinkButton to={`/tx/${txHash}/?tab=graph`}>
+          <StyledLinkButton to={`/tx/${txHash}/?tab=graph`}>
             <FontAwesomeIcon icon={faProjectDiagram} />
             View batch graph
-          </LinkButton>
+          </StyledLinkButton>
         </HeaderValue>
       </td>
     </tr>
@@ -257,9 +263,8 @@ const RowFill: React.FC<RowProps> = ({ trade }) => {
 const FillsTable: React.FC<Props> = (props) => {
   const { trades, order, tableState, showBorderTable = false } = props
   const tradeItems = (items: Trade[] | undefined): JSX.Element => {
-    let tableContent
     if (!items || items.length === 0) {
-      tableContent = (
+      return (
         <tr className="row-empty">
           <td className="row-td-empty">
             <EmptyItemWrapper>
@@ -269,7 +274,7 @@ const FillsTable: React.FC<Props> = (props) => {
         </tr>
       )
     } else {
-      tableContent = (
+        return (
         <>
           {items.map((item, i) => (
             <RowFill key={item.txHash} index={i + tableState.pageOffset} trade={item} />
@@ -277,7 +282,6 @@ const FillsTable: React.FC<Props> = (props) => {
         </>
       )
     }
-    return tableContent
   }
 
   return (

--- a/src/components/orders/OrderDetails/FillsTableWithData.tsx
+++ b/src/components/orders/OrderDetails/FillsTableWithData.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState, useEffect } from 'react'
+import React, { useContext } from 'react'
 
-import { DEFAULT_TIMEOUT } from 'const'
 import { Order } from 'api/operator'
 import { EmptyItemWrapper } from 'components/common/StyledUserDetailsTable'
 import { FillsTableContext } from './context/FillsTableContext'
@@ -13,30 +12,10 @@ export const FillsTableWithData: React.FC<{ areTokensLoaded: boolean; order: Ord
   areTokensLoaded,
   order,
 }) => {
-  const { trades, isLoading, tableState } = useContext(FillsTableContext)
+  const { trades, tableState } = useContext(FillsTableContext)
   const isFirstRender = useFirstRender()
-  const [isFirstLoading, setIsFirstLoading] = useState(true)
 
-  useEffect(() => {
-    setIsFirstLoading(true)
-  }, [isLoading])
-
-  useEffect(() => {
-    let timeOutMs = 0
-    if (!trades) {
-      timeOutMs = DEFAULT_TIMEOUT
-    }
-
-    const timeOutId: NodeJS.Timeout = setTimeout(() => {
-      setIsFirstLoading(false)
-    }, timeOutMs)
-
-    return (): void => {
-      clearTimeout(timeOutId)
-    }
-  }, [trades, trades?.length])
-
-  return isFirstRender || isFirstLoading || !areTokensLoaded ? (
+  return isFirstRender || !areTokensLoaded ? (
     <EmptyItemWrapper>
       <CowLoading />
     </EmptyItemWrapper>

--- a/src/components/token/TokenAmount/index.tsx
+++ b/src/components/token/TokenAmount/index.tsx
@@ -3,11 +3,21 @@ import BigNumber from 'bignumber.js'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 import { FormatAmountPrecision, formatSmartMaxPrecision, formattingAmountPrecision } from 'utils'
 
-// TODO: unify with TokenAmount in @cowprotocol/cowswap
-export function TokenAmount({ amount, token, symbol }: { amount: BigNumber, symbol?: string, token?: TokenErc20 | null }) {
-    const fullAmount = formatSmartMaxPrecision(amount, token || null)
-    const displayedAmount = formattingAmountPrecision(amount, token || null, FormatAmountPrecision.highPrecision)
-    const displayedSymbol = symbol || token?.symbol
+interface Props {
+  amount: BigNumber
+  symbol?: string
+  token?: TokenErc20 | null
+}
 
-    return <span title={fullAmount + ' ' + displayedSymbol}>{displayedAmount} {displayedSymbol}</span>
+// TODO: unify with TokenAmount in @cowprotocol/cowswap
+export const TokenAmount: React.FC<Props> = ({ amount, token, symbol }: Props) => {
+  const fullAmount = formatSmartMaxPrecision(amount, token || null)
+  const displayedAmount = formattingAmountPrecision(amount, token || null, FormatAmountPrecision.highPrecision)
+  const displayedSymbol = symbol || token?.symbol
+
+  return (
+    <span title={fullAmount + ' ' + displayedSymbol}>
+      {displayedAmount} {displayedSymbol}
+    </span>
+  )
 }

--- a/src/components/token/TokenAmount/index.tsx
+++ b/src/components/token/TokenAmount/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import BigNumber from 'bignumber.js'
+import { TokenErc20 } from '@gnosis.pm/dex-js'
+import { FormatAmountPrecision, formatSmartMaxPrecision, formattingAmountPrecision } from 'utils'
+
+// TODO: unify with TokenAmount in @cowprotocol/cowswap
+export function TokenAmount({ amount, token, symbol }: { amount: BigNumber, symbol?: string, token?: TokenErc20 | null }) {
+    const fullAmount = formatSmartMaxPrecision(amount, token || null)
+    const displayedAmount = formattingAmountPrecision(amount, token || null, FormatAmountPrecision.highPrecision)
+    const displayedSymbol = symbol || token?.symbol
+
+    return <span title={fullAmount + ' ' + displayedSymbol}>{displayedAmount} {displayedSymbol}</span>
+}

--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -1,14 +1,9 @@
-import { Trade as TradeMetaData } from '@cowprotocol/cow-sdk'
-import { getTrades, Order, Trade } from 'api/operator'
+import { getTrades, Order, RawTrade, Trade } from 'api/operator'
 import { useCallback, useEffect, useState } from 'react'
 import { useNetworkId } from 'state/network'
 import { Network, UiError } from 'types'
 import { transformTrade } from 'utils'
-
-type Params = {
-  owner?: string
-  orderId?: string
-}
+import { web3 } from 'apps/explorer/api'
 
 type Result = {
   trades: Trade[]
@@ -16,100 +11,110 @@ type Result = {
   isLoading: boolean
 }
 
-/**
- * Fetches trades for given filters
- * When no filter is given, fetches all trades for current network
- */
-export function useTrades(params: Params): Result {
-  const { owner, orderId } = params
+type TradesTimestamps = { [txHash: string]: number }
 
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<UiError>()
-  const [trades, setTrades] = useState<Trade[]>([])
+const tradesTimestampsCache: { [blockNumber: number]: Promise<number> } = {}
 
-  // Here we assume that we are already in the right network
-  // contrary to useOrder hook, where it searches all networks for a given orderId
-  const networkId = useNetworkId()
+async function fetchTradesTimestamps(rawTrades: RawTrade[]): Promise<TradesTimestamps> {
+  const requests = rawTrades.map(({ txHash, blockNumber }) => {
+    const cachedValue = tradesTimestampsCache[blockNumber]
 
-  const fetchTrades = useCallback(async (networkId: Network, owner?: string, orderId?: string): Promise<void> => {
-    setIsLoading(true)
-
-    try {
-      let trades: TradeMetaData[] = []
-      if (orderId) {
-        trades = await getTrades({ networkId, orderId })
-      } else if (owner) {
-        trades = await getTrades({ networkId, owner })
-      }
-
-      // TODO: fetch buy/sellToken objects
-      setTrades(trades.map((trade) => transformTrade(trade)))
-      setError(undefined)
-    } catch (e) {
-      const msg = `Failed to fetch trades`
-      console.error(msg, e)
-      setError({ message: msg, type: 'error' })
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!networkId) {
-      return
+    if (cachedValue) {
+      return cachedValue.then((timestamp) => ({ txHash, timestamp }))
     }
 
-    fetchTrades(networkId, owner, orderId)
-  }, [fetchTrades, networkId, orderId, owner])
+    const request = web3.eth.getBlock(blockNumber).then(({ timestamp }) => +timestamp)
 
-  return { trades, error, isLoading }
+    tradesTimestampsCache[blockNumber] = request
+
+    return request.then((timestamp) => ({ txHash, timestamp }))
+  })
+
+  const data = await Promise.all(requests)
+
+  return data.reduce((acc, val) => {
+    if (val.txHash) acc[val.txHash] = val.timestamp
+
+    return acc
+  }, {} as TradesTimestamps)
 }
 
 /**
  * Fetches trades for given order
  */
 export function useOrderTrades(order: Order | null): Result {
-  const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<UiError>()
   const [trades, setTrades] = useState<Trade[]>([])
+  const [rawTrades, setRawTrades] = useState<RawTrade[] | null>(null)
+  const [tradesTimestamps, setTradesTimestamps] = useState<TradesTimestamps>({})
 
   // Here we assume that we are already in the right network
   // contrary to useOrder hook, where it searches all networks for a given orderId
   const networkId = useNetworkId()
 
   const fetchTrades = useCallback(
-    async (controller: AbortController, _networkId: Network, _order: Order): Promise<void> => {
-      setIsLoading(true)
+    async (controller: AbortController, _networkId: Network): Promise<void> => {
+      if (!order) return
 
-      const { uid: orderId, buyToken, sellToken } = _order
+      const { uid: orderId } = order
 
       try {
-        const _trades = await getTrades({ networkId: _networkId, orderId })
+        const trades = await getTrades({ networkId: _networkId, orderId })
 
         if (controller.signal.aborted) return
 
-        setTrades(_trades.map((trade) => ({ ...transformTrade(trade), buyToken, sellToken })))
+        setRawTrades(trades)
         setError(undefined)
       } catch (e) {
         const msg = `Failed to fetch trades`
         console.error(msg, e)
+
+        setRawTrades([])
         setError({ message: msg, type: 'error' })
-      } finally {
-        setIsLoading(false)
       }
     },
-    [],
+    [order],
   )
+
+  // Fetch blocks timestamps for trades
+  useEffect(() => {
+    if (!rawTrades) return
+
+    fetchTradesTimestamps(rawTrades)
+      .then(setTradesTimestamps)
+      .catch((error) => {
+        console.error('Trades timestamps fetching error: ', error)
+
+        setTradesTimestamps({})
+      })
+  }, [rawTrades])
+
+  // Transform trades adding tokens and timestamps
+  useEffect(() => {
+    if (!order || !rawTrades) return
+
+    const { buyToken, sellToken } = order
+
+    const trades = rawTrades.map((trade) => {
+      const timestamp = trade.txHash ? tradesTimestamps[trade.txHash] : undefined
+
+      return { ...transformTrade(trade, timestamp), buyToken, sellToken }
+    })
+
+    setTrades(trades)
+  }, [order, rawTrades, tradesTimestamps])
 
   const executedSellAmount = order?.executedSellAmount.toString()
   const executedBuyAmount = order?.executedBuyAmount.toString()
+
   useEffect(() => {
     if (!networkId || !order?.uid) {
       return
     }
+
     const controller = new AbortController()
 
-    fetchTrades(controller, networkId, order)
+    fetchTrades(controller, networkId)
     return (): void => controller.abort()
     // Depending on order UID to avoid re-fetching when obj changes but ID remains the same
     // Depending on `executedBuy/SellAmount`s string to force a refetch when there are new trades
@@ -117,5 +122,5 @@ export function useOrderTrades(order: Order | null): Result {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchTrades, networkId, order?.uid, executedSellAmount, executedBuyAmount])
 
-  return { trades, error, isLoading }
+  return { trades, error, isLoading: rawTrades === null }
 }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -351,23 +351,14 @@ export function transformOrder(rawOrder: RawOrder): Order {
     filledPercentage,
     surplusAmount,
     surplusPercentage,
-  }
+  } as Order
 }
 
 /**
  * Transforms a RawTrade into a Trade object
  */
-export function transformTrade(rawTrade: TradeMetaData & { executionTime?: string }): Trade {
-  const {
-    orderUid,
-    buyAmount,
-    sellAmount,
-    sellAmountBeforeFees,
-    buyToken,
-    sellToken,
-    executionTime = '',
-    ...rest
-  } = rawTrade
+export function transformTrade(rawTrade: TradeMetaData, executionTimestamp?: number): Trade {
+  const { orderUid, buyAmount, sellAmount, sellAmountBeforeFees, buyToken, sellToken, ...rest } = rawTrade
 
   return {
     ...rest,
@@ -377,6 +368,6 @@ export function transformTrade(rawTrade: TradeMetaData & { executionTime?: strin
     sellAmountBeforeFees: new BigNumber(sellAmountBeforeFees),
     buyTokenAddress: buyToken,
     sellTokenAddress: sellToken,
-    executionTime: new Date(executionTime) || null,
+    executionTime: executionTimestamp ? new Date(executionTimestamp * 1000) : null,
   }
 }


### PR DESCRIPTION
# Summary

Reference: https://github.com/cowprotocol/explorer/pull/413#issuecomment-1491756414

## Changes
1. Made FILLED (in the header) column a little wider
2. Fixed displaying of order assets info in the top of the page (using `<TokenAmount>`)
3. Added `<TokenAmount>` component for buy/sell/execution amounts. It helps with displaying them short
4. Fixed displaying of "View batch graph" button, it was too big for mobile view
5. Fixed global layout (`MainWrapper`) to fix the page in mobile view. Warning! This change might break smth on other pages
6. Fixed execution price calculation for Fills table
7. Added control to inverse execution price 

## Background
1. `<TokenAmount>` - a new component that render amount with up to 8 decimals and show the full amount on hover of displayed one

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/7122625/230064120-d6ab902f-5572-4aea-bc96-e4fdf40e3ee4.png">

<img width="406" alt="image" src="https://user-images.githubusercontent.com/7122625/230064191-67405520-dabe-40e2-af27-79ff09f9e50f.png">

