### PR TITLE
Execution time for trades table

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[{*.ts,*.tsx}]
+ij_typescript_force_quote_style = true
+ij_typescript_use_double_quotes = false
+ij_typescript_use_semicolon_after_statement = false

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,
+  "engines": {
+    "node": "16"
+  },
   "scripts": {
     "start": "npm run start:explorer",
     "start:explorer": "APP=explorer npm run start:apps",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "",
   "main": "src/index.js",
   "sideEffects": false,
-  "engines": {
-    "node": "16"
-  },
   "scripts": {
     "start": "npm run start:explorer",
     "start:explorer": "APP=explorer npm run start:apps",

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -66,7 +66,7 @@ export type Trade = Pick<RawTrade, 'blockNumber' | 'logIndex' | 'owner' | 'txHas
   buyTokenAddress: string
   sellToken?: TokenErc20 | null
   sellTokenAddress: string
-  executionTime: Date
+  executionTime: Date | null
   surplusAmount?: BigNumber
   surplusPercentage?: BigNumber
 }

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -43,18 +43,22 @@ const TableHeading = styled.div`
   padding: 1.6rem;
   display: flex;
   gap: 2rem;
+
   ${media.mobile} {
     flex-direction: column;
     gap: 1rem;
   }
+
   .title {
     text-transform: uppercase;
     font-size: 1.1rem;
   }
+
   .fillNumber {
     font-size: 3.2rem;
     margin: 1.5rem 0 1rem 0;
     color: ${({ theme }): string => theme.green};
+
     ${media.mobile} {
       font-size: 2.8rem;
     }
@@ -63,9 +67,11 @@ const TableHeading = styled.div`
   .priceNumber {
     font-size: 2.2rem;
     margin: 1rem 0;
+
     ${media.mobile} {
       font-size: 1.8rem;
     }
+
     span {
       line-height: 1;
     }
@@ -77,12 +83,15 @@ const TableHeadingContent = styled.div`
   flex-direction: column;
   justify-content: center;
   width: 27rem;
+
   ${media.mobile} {
     flex-direction: column;
   }
+
   .progress-line {
     width: 100%;
   }
+
   &.limit-price {
     width: 38rem;
   }
@@ -147,14 +156,14 @@ export function FilledProgress(props: Props): JSX.Element {
       <OrderAssetsInfoWrapper>
         <b>
           {/* Executed part (bought/sold tokens) */}
-          <TokenAmount amount={filledAmountWithFee} token={mainToken} symbol={mainSymbol}/>
+          <TokenAmount amount={filledAmountWithFee} token={mainToken} symbol={mainSymbol} />
         </b>{' '}
         {!fullyFilled && (
           // Show the total amount to buy/sell. Only for orders that are not 100% executed
           <>
             of{' '}
             <b>
-              <TokenAmount amount={mainAmount} token={mainToken} symbol={mainSymbol}/>
+              <TokenAmount amount={mainAmount} token={mainToken} symbol={mainSymbol} />
             </b>{' '}
           </>
         )}
@@ -166,7 +175,7 @@ export function FilledProgress(props: Props): JSX.Element {
           <>
             for a total of{' '}
             <b>
-              <TokenAmount amount={swappedAmountWithFee} token={swappedToken} symbol={swappedSymbol}/>
+              <TokenAmount amount={swappedAmountWithFee} token={swappedToken} symbol={swappedSymbol} />
             </b>
           </>
         )}

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faExchangeAlt, faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
@@ -32,13 +32,17 @@ const Wrapper = styled(StyledUserDetailsTable)`
       padding: 0 2rem;
     }
   }
+
   > tbody {
     min-height: 37rem;
     border-bottom: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
+
     > tr {
       min-height: 7.4rem;
+
       &.header-row {
         display: none;
+
         ${media.mobile} {
           display: flex;
           background: transparent;
@@ -47,10 +51,12 @@ const Wrapper = styled(StyledUserDetailsTable)`
           margin: 0;
           box-shadow: none;
           min-height: 2rem;
+
           td {
             padding: 0;
             margin: 0;
             margin-top: 1rem;
+
             .mobile-header {
               margin: 0;
             }
@@ -58,35 +64,43 @@ const Wrapper = styled(StyledUserDetailsTable)`
         }
       }
     }
+
     > tr > td:first-child {
       padding: 0 2rem;
     }
   }
+
   > thead > tr,
   > tbody > tr {
     grid-template-columns: 4fr 2fr 3fr 3fr 3.5fr 3fr 4fr;
   }
+
   > tbody > tr > td:nth-child(8),
   > thead > tr > th:nth-child(8) {
     justify-content: center;
   }
+
   tr > td {
     span.span-inside-tooltip {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
+
       img {
         padding: 0;
       }
     }
   }
+
   ${media.mobile} {
     > thead > tr {
       display: none;
+
       > th:first-child {
         padding: 0 1rem;
       }
     }
+
     > tbody > tr {
       grid-template-columns: none;
       border: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
@@ -94,14 +108,17 @@ const Wrapper = styled(StyledUserDetailsTable)`
       border-radius: 6px;
       margin-top: 10px;
       padding: 12px;
+
       &:hover {
         background: none;
         backdrop-filter: none;
       }
+
       td:first-child {
         padding: 0 1rem;
       }
     }
+
     tr > td {
       display: flex;
       flex: 1;
@@ -110,14 +127,17 @@ const Wrapper = styled(StyledUserDetailsTable)`
       margin: 0;
       margin-bottom: 18px;
       min-height: 32px;
+
       span.span-inside-tooltip {
         align-items: flex-end;
         flex-direction: column;
+
         img {
           margin-left: 0;
         }
       }
     }
+
     > tbody > tr > td,
     > thead > tr > th {
       :nth-child(4),
@@ -128,32 +148,39 @@ const Wrapper = styled(StyledUserDetailsTable)`
         justify-content: space-between;
       }
     }
+
     .header-value {
       flex-wrap: wrap;
       text-align: end;
     }
+
     .span-copybtn-wrap {
       display: flex;
       flex-wrap: nowrap;
+
       span {
         display: flex;
         align-items: center;
       }
+
       .copy-text {
         display: none;
       }
     }
   }
+
   overflow: auto;
 `
 
 const HeaderTitle = styled.span`
   display: none;
+
   ${media.mobile} {
     font-weight: 600;
     align-items: center;
     display: flex;
     margin-right: 3rem;
+
     svg {
       margin-left: 5px;
     }
@@ -161,6 +188,7 @@ const HeaderTitle = styled.span`
 `
 const HeaderValue = styled.span<{ captionColor?: 'green' | 'red1' | 'grey' }>`
   color: ${({ theme, captionColor }): string => (captionColor ? theme[captionColor] : theme.textPrimary1)};
+
   ${media.mobile} {
     flex-wrap: wrap;
     text-align: end;
@@ -206,7 +234,7 @@ function calculateExecutionPrice(
   sellAmount: BigNumber,
   buyAmount: BigNumber,
   sellToken?: TokenErc20 | null,
-  buyToken?: TokenErc20 | null
+  buyToken?: TokenErc20 | null,
 ): BigNumber | null {
   if (!sellToken || !buyToken) return null
 
@@ -216,9 +244,7 @@ function calculateExecutionPrice(
   return calculatePrice({
     numerator: isPriceInverted ? buyData : sellData,
     denominator: isPriceInverted ? sellData : buyData,
-  }).multipliedBy(
-    TEN_BIG_NUMBER.exponentiatedBy((isPriceInverted ? buyToken : sellToken).decimals)
-  )
+  }).multipliedBy(TEN_BIG_NUMBER.exponentiatedBy((isPriceInverted ? buyToken : sellToken).decimals))
 }
 
 const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) => {
@@ -260,24 +286,24 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) =
       <td>
         <HeaderTitle>Buy amount</HeaderTitle>
         <HeaderValue>
-          <TokenAmount amount={buyAmount} token={buyToken}/>
+          <TokenAmount amount={buyAmount} token={buyToken} />
         </HeaderValue>
       </td>
       <td>
         <HeaderTitle>Sell amount</HeaderTitle>
         <HeaderValue>
-          <TokenAmount amount={sellAmount} token={sellToken}/>
+          <TokenAmount amount={sellAmount} token={sellToken} />
         </HeaderValue>
       </td>
       <td>
         <HeaderTitle>Execution price {invertButton}</HeaderTitle>
-        <HeaderValue>
-            {executionPrice && <TokenAmount amount={executionPrice} token={executionToken}/>}
-        </HeaderValue>
+        <HeaderValue>{executionPrice && <TokenAmount amount={executionPrice} token={executionToken} />}</HeaderValue>
       </td>
       <td>
         <HeaderTitle>Execution time</HeaderTitle>
-        <HeaderValue>{executionTime ? <DateDisplay date={executionTime} showIcon={true} /> : <StyledShimmerBar />}</HeaderValue>
+        <HeaderValue>
+          {executionTime ? <DateDisplay date={executionTime} showIcon={true} /> : <StyledShimmerBar />}
+        </HeaderValue>
       </td>
       <td>
         <HeaderTitle></HeaderTitle>
@@ -296,7 +322,11 @@ const FillsTable: React.FC<Props> = (props) => {
   const { trades, order, tableState, showBorderTable = false } = props
   const [isPriceInverted, setIsPriceInverted] = useState(false)
 
-  const invertButton = <Icon icon={faExchangeAlt} onClick={() => setIsPriceInverted(value => !value)} />
+  const onInvert = useCallback(() => {
+    setIsPriceInverted((value) => !value)
+  }, [])
+
+  const invertButton = <Icon icon={faExchangeAlt} onClick={onInvert} />
 
   const tradeItems = (items: Trade[] | undefined): JSX.Element => {
     if (!items || items.length === 0) {
@@ -310,7 +340,7 @@ const FillsTable: React.FC<Props> = (props) => {
         </tr>
       )
     } else {
-        return (
+      return (
         <>
           {items.map((item, i) => (
             <RowFill
@@ -318,7 +348,8 @@ const FillsTable: React.FC<Props> = (props) => {
               index={i + tableState.pageOffset}
               trade={item}
               invertButton={invertButton}
-              isPriceInverted={isPriceInverted} />
+              isPriceInverted={isPriceInverted}
+            />
           ))}
         </>
       )

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -24,6 +24,7 @@ import Icon from 'components/Icon'
 import { calculatePrice, TokenErc20 } from '@gnosis.pm/dex-js'
 import { TEN_BIG_NUMBER } from 'const'
 import BigNumber from 'bignumber.js'
+import ShimmerBar from 'apps/explorer/components/common/ShimmerBar'
 
 const Wrapper = styled(StyledUserDetailsTable)`
   > thead {
@@ -63,7 +64,7 @@ const Wrapper = styled(StyledUserDetailsTable)`
   }
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 4fr 2fr 3fr 3fr 3fr 4fr 4fr;
+    grid-template-columns: 4fr 2fr 3fr 3fr 3.5fr 3fr 4fr;
   }
   > tbody > tr > td:nth-child(8),
   > thead > tr > th:nth-child(8) {
@@ -182,6 +183,11 @@ const StyledLinkButton = styled(LinkButton)`
   }
 `
 
+const StyledShimmerBar = styled(ShimmerBar)`
+  min-height: 20px;
+  min-width: 100px;
+`
+
 export type Props = StyledUserDetailsTableProps & {
   trades: Trade[] | undefined
   order: Order | null
@@ -224,8 +230,6 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInversed }) => {
   const buyToken = tokens[buyTokenAddress]
   const sellToken = tokens[sellTokenAddress]
 
-  const executionTimeFormatted =
-    executionTime instanceof Date && !isNaN(Date.parse(executionTime.toString())) ? executionTime : new Date()
   const executionPrice = calculateExecutionPrice(isPriceInversed, sellAmount, buyAmount, sellToken, buyToken)
   const executionToken = isPriceInversed ? buyToken : sellToken
 
@@ -272,7 +276,7 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInversed }) => {
       </td>
       <td>
         <HeaderTitle>Execution time</HeaderTitle>
-        <HeaderValue>{<DateDisplay date={executionTimeFormatted} showIcon={true} />}</HeaderValue>
+        <HeaderValue>{executionTime ? <DateDisplay date={executionTime} showIcon={true} /> : <StyledShimmerBar />}</HeaderValue>
       </td>
       <td>
         <HeaderTitle></HeaderTitle>

--- a/src/components/orders/OrderDetails/FillsTableWithData.tsx
+++ b/src/components/orders/OrderDetails/FillsTableWithData.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState, useEffect } from 'react'
+import React, { useContext } from 'react'
 
-import { DEFAULT_TIMEOUT } from 'const'
 import { Order } from 'api/operator'
 import { EmptyItemWrapper } from 'components/common/StyledUserDetailsTable'
 import { FillsTableContext } from './context/FillsTableContext'
@@ -13,30 +12,10 @@ export const FillsTableWithData: React.FC<{ areTokensLoaded: boolean; order: Ord
   areTokensLoaded,
   order,
 }) => {
-  const { trades, isLoading, tableState } = useContext(FillsTableContext)
+  const { trades, tableState } = useContext(FillsTableContext)
   const isFirstRender = useFirstRender()
-  const [isFirstLoading, setIsFirstLoading] = useState(true)
 
-  useEffect(() => {
-    setIsFirstLoading(true)
-  }, [isLoading])
-
-  useEffect(() => {
-    let timeOutMs = 0
-    if (!trades) {
-      timeOutMs = DEFAULT_TIMEOUT
-    }
-
-    const timeOutId: NodeJS.Timeout = setTimeout(() => {
-      setIsFirstLoading(false)
-    }, timeOutMs)
-
-    return (): void => {
-      clearTimeout(timeOutId)
-    }
-  }, [trades, trades?.length])
-
-  return isFirstRender || isFirstLoading || !areTokensLoaded ? (
+  return isFirstRender || !areTokensLoaded ? (
     <EmptyItemWrapper>
       <CowLoading />
     </EmptyItemWrapper>

--- a/src/components/token/TokenAmount/index.tsx
+++ b/src/components/token/TokenAmount/index.tsx
@@ -3,11 +3,21 @@ import BigNumber from 'bignumber.js'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 import { FormatAmountPrecision, formatSmartMaxPrecision, formattingAmountPrecision } from 'utils'
 
-// TODO: unify with TokenAmount in @cowprotocol/cowswap
-export function TokenAmount({ amount, token, symbol }: { amount: BigNumber, symbol?: string, token?: TokenErc20 | null }) {
-    const fullAmount = formatSmartMaxPrecision(amount, token || null)
-    const displayedAmount = formattingAmountPrecision(amount, token || null, FormatAmountPrecision.highPrecision)
-    const displayedSymbol = symbol || token?.symbol
+interface Props {
+  amount: BigNumber
+  symbol?: string
+  token?: TokenErc20 | null
+}
 
-    return <span title={fullAmount + ' ' + displayedSymbol}>{displayedAmount} {displayedSymbol}</span>
+// TODO: unify with TokenAmount in @cowprotocol/cowswap
+export const TokenAmount: React.FC<Props> = ({ amount, token, symbol }: Props) => {
+  const fullAmount = formatSmartMaxPrecision(amount, token || null)
+  const displayedAmount = formattingAmountPrecision(amount, token || null, FormatAmountPrecision.highPrecision)
+  const displayedSymbol = symbol || token?.symbol
+
+  return (
+    <span title={fullAmount + ' ' + displayedSymbol}>
+      {displayedAmount} {displayedSymbol}
+    </span>
+  )
 }

--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -89,7 +89,9 @@ export function useOrderTrades(order: Order | null): Result {
     const { buyToken, sellToken } = order
 
     const trades = rawTrades.map((trade) => {
-      return { ...transformTrade(trade, tradesTimestamps[trade.txHash]), buyToken, sellToken }
+      const timestamp = trade.txHash ? tradesTimestamps[trade.txHash] : undefined
+
+      return { ...transformTrade(trade, timestamp), buyToken, sellToken }
     })
 
     setTrades(trades)

--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -24,7 +24,8 @@ async function fetchTradesTimestamps(rawTrades: RawTrade[]): Promise<TradesTimes
   const data = await Promise.all(requests)
 
   return data.reduce((acc, val) => {
-    acc[val.txHash] = val.timestamp
+    if (val.txHash) acc[val.txHash] = val.timestamp
+
     return acc
   }, {} as TradesTimestamps)
 }

--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -11,7 +11,9 @@ type Result = {
   isLoading: boolean
 }
 
-async function fetchTradesTimestamps(rawTrades: RawTrade[]): Promise<{[txHash: string]: number}> {
+type TradesTimestamps = { [txHash: string]: number }
+
+async function fetchTradesTimestamps(rawTrades: RawTrade[]): Promise<TradesTimestamps> {
   const requests = rawTrades.map(({ txHash, blockNumber }) => {
     return web3.eth.getBlock(blockNumber).then(res => ({
       txHash,
@@ -24,7 +26,7 @@ async function fetchTradesTimestamps(rawTrades: RawTrade[]): Promise<{[txHash: s
   return data.reduce((acc, val) => {
     acc[val.txHash] = val.timestamp
     return acc
-  }, {})
+  }, {} as TradesTimestamps)
 }
 
 /**
@@ -35,7 +37,7 @@ export function useOrderTrades(order: Order | null): Result {
   const [error, setError] = useState<UiError>()
   const [trades, setTrades] = useState<Trade[]>([])
   const [rawTrades, setRawTrades] = useState<RawTrade[]>([])
-  const [tradesTimestamps, setTradesTimestamps] = useState<{[txHash: string]: number}>({})
+  const [tradesTimestamps, setTradesTimestamps] = useState<TradesTimestamps>({})
 
   // Here we assume that we are already in the right network
   // contrary to useOrder hook, where it searches all networks for a given orderId

--- a/src/hooks/useOperatorTrades.ts
+++ b/src/hooks/useOperatorTrades.ts
@@ -84,8 +84,6 @@ export function useOrderTrades(order: Order | null): Result {
 
   // Fetch blocks timestamps for trades
   useEffect(() => {
-    setTradesTimestamps({})
-
     fetchTradesTimestamps(rawTrades).then(setTradesTimestamps).catch(error => {
       console.error('Trades timestamps fetching error: ', error)
 

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -351,13 +351,13 @@ export function transformOrder(rawOrder: RawOrder): Order {
     filledPercentage,
     surplusAmount,
     surplusPercentage,
-  }
+  } as Order
 }
 
 /**
  * Transforms a RawTrade into a Trade object
  */
-export function transformTrade(rawTrade: TradeMetaData & { executionTime?: string }): Trade {
+export function transformTrade(rawTrade: TradeMetaData, executionTimestamp?: number): Trade {
   const {
     orderUid,
     buyAmount,
@@ -365,7 +365,6 @@ export function transformTrade(rawTrade: TradeMetaData & { executionTime?: strin
     sellAmountBeforeFees,
     buyToken,
     sellToken,
-    executionTime = '',
     ...rest
   } = rawTrade
 
@@ -377,6 +376,6 @@ export function transformTrade(rawTrade: TradeMetaData & { executionTime?: strin
     sellAmountBeforeFees: new BigNumber(sellAmountBeforeFees),
     buyTokenAddress: buyToken,
     sellTokenAddress: sellToken,
-    executionTime: new Date(executionTime) || null,
+    executionTime: executionTimestamp ? new Date(executionTimestamp * 1000) : null,
   }
 }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -358,15 +358,7 @@ export function transformOrder(rawOrder: RawOrder): Order {
  * Transforms a RawTrade into a Trade object
  */
 export function transformTrade(rawTrade: TradeMetaData, executionTimestamp?: number): Trade {
-  const {
-    orderUid,
-    buyAmount,
-    sellAmount,
-    sellAmountBeforeFees,
-    buyToken,
-    sellToken,
-    ...rest
-  } = rawTrade
+  const { orderUid, buyAmount, sellAmount, sellAmountBeforeFees, buyToken, sellToken, ...rest } = rawTrade
 
   return {
     ...rest,


### PR DESCRIPTION
# Summary

Closes #424

## Changes
1. For trades added fetching of blocks timestamps using `web3.eth.getBlock()`
2. The loading shimmer is displayed while blocks timestamps are loading
4. The trades table must be displayed even if we couldn't load timestamps (due to separated `useEffect()`)

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/7122625/230102825-e29d23e6-d5a1-4b2f-a5c4-0a65eff4e16d.png">

<img width="718" alt="image" src="https://user-images.githubusercontent.com/7122625/230103428-4a8d0981-645b-41b1-88c5-08c063d40fee.png">

