### PR TITLE
Do not show fills tab for fill or kill orders

### DIFF
--- a/src/components/orders/DetailsTable/DetailsTable.stories.tsx
+++ b/src/components/orders/DetailsTable/DetailsTable.stories.tsx
@@ -30,7 +30,7 @@ const order = {
   txHash: '0x489d8fd1efd43394c7c2b26216f36f1ab49b8d67623047e0fcb60efa2a2c420b',
 }
 
-const defaultProps: Props = { order, areTradesLoading: false, viewFills: () => null }
+const defaultProps: Props = { order, areTradesLoading: false, showFillsButton: false, viewFills: () => null }
 
 export const DefaultFillOrKill = Template.bind({})
 DefaultFillOrKill.args = { ...defaultProps }

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -164,12 +164,13 @@ export const LinkButton = styled(LinkWithPrefixNetwork)`
 
 export type Props = {
   order: Order
+  showFillsButton: boolean | undefined
   areTradesLoading: boolean
   viewFills: () => void
 }
 
 export function DetailsTable(props: Props): JSX.Element | null {
-  const { order, areTradesLoading, viewFills } = props
+  const { order, areTradesLoading, showFillsButton, viewFills } = props
   const {
     uid,
     shortId,
@@ -349,8 +350,8 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <td>
                 <Wrapper>
                   <FilledProgress order={order} />
-                  {partiallyFillable && !txHash && (
-                    <LinkButton onClickOptional={(): void => viewFills()} to={`/orders/${uid}/?tab=fills`}>
+                  {showFillsButton && (
+                    <LinkButton onClickOptional={viewFills} to={`/orders/${uid}/?tab=fills`}>
                       <FontAwesomeIcon icon={faFill} />
                       View fills
                     </LinkButton>

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -349,10 +349,12 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <td>
                 <Wrapper>
                   <FilledProgress order={order} />
-                  <LinkButton onClickOptional={(): void => viewFills()} to={`/orders/${uid}/?tab=fills`}>
-                    <FontAwesomeIcon icon={faFill} />
-                    View fills
-                  </LinkButton>
+                  {partiallyFillable && !txHash && (
+                    <LinkButton onClickOptional={(): void => viewFills()} to={`/orders/${uid}/?tab=fills`}>
+                      <FontAwesomeIcon icon={faFill} />
+                      View fills
+                    </LinkButton>
+                  )}
                 </Wrapper>
               </td>
             </tr>

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -243,7 +243,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               />
             </td>
           </tr>
-          {!partiallyFillable && (
+          {(!partiallyFillable || txHash) && (
             <tr>
               <td>
                 <HelpTooltip tooltip={tooltip.hash} /> Transaction hash

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -298,7 +298,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.type} /> Type
             </td>
             <td>
-              {capitalize(kind)} {order.class} order {!partiallyFillable && '(Fill or Kill)'}
+              {capitalize(kind)} {order.class} order {partiallyFillable ? '(Partially fillable)' : '(Fill or Kill)'}
             </td>
           </tr>
           <tr>

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -89,34 +89,39 @@ const tabItems = (
   const isLoadingForTheFirstTime = isOrderLoading && !areTokensLoaded
   const filledPercentage = order?.filledPercentage && formatPercentage(order.filledPercentage)
 
-  return [
-    {
-      id: TabView.OVERVIEW,
-      tab: <span>Overview</span>,
-      content: (
-        <>
-          {order && areTokensLoaded && (
-            <DetailsTable
-              order={order}
-              viewFills={(): void => onChangeTab(TabView.FILLS)}
-              areTradesLoading={areTradesLoading}
-            />
-          )}
-          {!isOrderLoading && order && !areTokensLoaded && <p>Not able to load tokens</p>}
-          {isLoadingForTheFirstTime && (
-            <EmptyItemWrapper>
-              <CowLoading />
-            </EmptyItemWrapper>
-          )}
-        </>
-      ),
-    },
-    {
-      id: TabView.FILLS,
-      tab: <>{filledPercentage ? <span>Fills ({filledPercentage})</span> : <span>Fills</span>}</>,
-      content: <FillsTableWithData order={order} areTokensLoaded={!!areTokensLoaded} />,
-    },
-  ]
+  const detailsTab = {
+    id: TabView.OVERVIEW,
+    tab: <span>Overview</span>,
+    content: (
+      <>
+        {order && areTokensLoaded && (
+          <DetailsTable
+            order={order}
+            viewFills={(): void => onChangeTab(TabView.FILLS)}
+            areTradesLoading={areTradesLoading}
+          />
+        )}
+        {!isOrderLoading && order && !areTokensLoaded && <p>Not able to load tokens</p>}
+        {isLoadingForTheFirstTime && (
+          <EmptyItemWrapper>
+            <CowLoading />
+          </EmptyItemWrapper>
+        )}
+      </>
+    ),
+  }
+
+  if (!order?.partiallyFillable) {
+    return [detailsTab]
+  }
+
+  const fillsTab = {
+    id: TabView.FILLS,
+    tab: <>{filledPercentage ? <span>Fills ({filledPercentage})</span> : <span>Fills</span>}</>,
+    content: <FillsTableWithData order={order} areTokensLoaded={!!areTokensLoaded} />,
+  }
+
+  return [detailsTab, fillsTab]
 }
 
 /**

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -111,7 +111,7 @@ const tabItems = (
     ),
   }
 
-  if (!order?.partiallyFillable || order.txHash) {
+  if (!order?.partiallyFillable || order.txHash || !trades.length) {
     return [detailsTab]
   }
 

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -111,7 +111,7 @@ const tabItems = (
     ),
   }
 
-  if (!order?.partiallyFillable) {
+  if (!order?.partiallyFillable || order.txHash) {
     return [detailsTab]
   }
 

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -88,7 +88,7 @@ const tabItems = (
   const areTokensLoaded = order?.buyToken && order?.sellToken
   const isLoadingForTheFirstTime = isOrderLoading && !areTokensLoaded
   const filledPercentage = order?.filledPercentage && formatPercentage(order.filledPercentage)
-  const showFills = order?.partiallyFillable && !order.txHash
+  const showFills = order?.partiallyFillable && !order.txHash && trades.length > 1
 
   const detailsTab = {
     id: TabView.OVERVIEW,

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -88,6 +88,7 @@ const tabItems = (
   const areTokensLoaded = order?.buyToken && order?.sellToken
   const isLoadingForTheFirstTime = isOrderLoading && !areTokensLoaded
   const filledPercentage = order?.filledPercentage && formatPercentage(order.filledPercentage)
+  const showFillsButton = order?.partiallyFillable && !order.txHash && trades.length > 1
 
   const detailsTab = {
     id: TabView.OVERVIEW,
@@ -97,6 +98,7 @@ const tabItems = (
         {order && areTokensLoaded && (
           <DetailsTable
             order={order}
+            showFillsButton={showFillsButton}
             viewFills={(): void => onChangeTab(TabView.FILLS)}
             areTradesLoading={areTradesLoading}
           />

--- a/src/components/orders/OrderDetails/index.tsx
+++ b/src/components/orders/OrderDetails/index.tsx
@@ -88,7 +88,7 @@ const tabItems = (
   const areTokensLoaded = order?.buyToken && order?.sellToken
   const isLoadingForTheFirstTime = isOrderLoading && !areTokensLoaded
   const filledPercentage = order?.filledPercentage && formatPercentage(order.filledPercentage)
-  const showFillsButton = order?.partiallyFillable && !order.txHash && trades.length > 1
+  const showFills = order?.partiallyFillable && !order.txHash
 
   const detailsTab = {
     id: TabView.OVERVIEW,
@@ -98,7 +98,7 @@ const tabItems = (
         {order && areTokensLoaded && (
           <DetailsTable
             order={order}
-            showFillsButton={showFillsButton}
+            showFillsButton={showFills}
             viewFills={(): void => onChangeTab(TabView.FILLS)}
             areTradesLoading={areTradesLoading}
           />
@@ -113,7 +113,7 @@ const tabItems = (
     ),
   }
 
-  if (!order?.partiallyFillable || order.txHash || !trades.length) {
+  if (!showFills) {
     return [detailsTab]
   }
 
@@ -129,10 +129,10 @@ const tabItems = (
 /**
  * Get the order with txHash set if it has a single trade
  *
- * That is the case for closed orders, fill or kill or partial fill that has a single trade
+ * That is the case for any filled fill or kill or a partial fill that has a single trade
  */
 function getOrderWithTxHash(order: Order | null, trades: Trade[]): Order | null {
-  if (order && trades.length === 1 && order.status !== 'open') {
+  if (order && trades.length === 1) {
     return { ...order, txHash: trades[0].txHash || undefined }
   }
   return order


### PR DESCRIPTION
# Summary

Do not show fills tab for fill or kill orders

# To Test

1. Open the details page for a fill or kill order
* Should not have the `fills` tab
2. Open the details page for a partially fillable order
* Should have the `fills` tab