### PR TITLE
Partial fills table adjust columns

### DIFF
--- a/src/apps/explorer/components/TokensTableWidget/index.tsx
+++ b/src/apps/explorer/components/TokensTableWidget/index.tsx
@@ -59,8 +59,10 @@ const ExplorerCustomTab = styled(ExplorerTabs)`
       flex-direction: column;
     }
   }
+
   .tab-extra-content {
     justify-content: center;
+    padding: 1.4rem 0;
   }
 `
 

--- a/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.tsx
+++ b/src/apps/explorer/components/common/ExplorerTabs/ExplorerTabs.tsx
@@ -35,9 +35,6 @@ const StyledTabs = styled.div`
 
   .tab-content {
     padding: 20px 16px;
-    ${media.mediumDown} {
-      padding: 0;
-    }
   }
 
   .tab-extra-content {

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -4,10 +4,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 const Icon = styled(FontAwesomeIcon)`
   background: ${({ theme }): string => theme.grey}33; /* 33==20% transparency in hex */
   border-radius: 1rem;
-  width: 1.2rem !important; /* FontAwesome sets it to 1em with higher specificity */
-  height: 1.2rem;
+  width: 1rem !important; /* FontAwesome sets it to 1em with higher specificity */
+  height: 1rem;
   padding: 0.4rem;
-  margin-left: 0.5rem;
+  margin: 0 0 0 0.5rem;
   cursor: pointer;
 `
 

--- a/src/components/common/StyledUserDetailsTable.tsx
+++ b/src/components/common/StyledUserDetailsTable.tsx
@@ -31,17 +31,21 @@ const StyledUserDetailsTable = styled(SimpleTable)<StyledUserDetailsTableProps>`
   thead tr th {
     color: ${({ theme }): string => theme.textPrimary1};
     font-style: normal;
-    font-weight: 800;
+    font-weight: ${({ theme }): string => theme.fontBold};
     font-size: 13px;
     line-height: 16px;
     height: 50px;
     border-bottom: ${({ theme }): string => `1px solid ${theme.borderPrimary}`};
-    gap: 6px;
+  }
+
+  thead tr th > span {
+    white-space: pre;
   }
 
   thead {
     position: inherit;
   }
+
   thead tr {
     width: 100%;
   }

--- a/src/components/common/SurplusComponent/index.tsx
+++ b/src/components/common/SurplusComponent/index.tsx
@@ -3,12 +3,24 @@ import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import { formatPercentage, Surplus } from 'utils'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 import { TokenAmount } from 'components/token/TokenAmount'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
 
-const Percentage = styled.span`
+const IconWrapper = styled(FontAwesomeIcon)`
+  padding: 0 0.5rem 0 0;
+  margin: 0;
+  box-sizing: content-box;
+
+  :hover {
+    cursor: pointer;
+  }
+`
+
+export const Percentage = styled.span`
   color: ${({ theme }): string => theme.green};
 `
 
-const Amount = styled.span<{ showHiddenSection: boolean; strechHiddenSection?: boolean }>`
+export const Amount = styled.span<{ showHiddenSection: boolean; strechHiddenSection?: boolean }>`
   display: ${({ showHiddenSection }): string => (showHiddenSection ? 'flex' : 'none')};
   ${({ strechHiddenSection }): FlattenSimpleInterpolation | false | undefined =>
     strechHiddenSection &&
@@ -24,10 +36,12 @@ export type SurplusComponentProps = {
   token: TokenErc20 | null
   showHidden?: boolean
   className?: string
+  icon?: IconDefinition
+  iconColor?: string
 }
 
 export const SurplusComponent: React.FC<SurplusComponentProps> = (props) => {
-  const { surplus, token, showHidden, className } = props
+  const { surplus, token, showHidden, className, icon, iconColor } = props
 
   if (!surplus || !token) {
     return null
@@ -36,11 +50,12 @@ export const SurplusComponent: React.FC<SurplusComponentProps> = (props) => {
   const { percentage, amount } = surplus
 
   return (
-    <div className={className}>
+    <span className={className}>
+      {icon && <IconWrapper icon={icon} color={iconColor} />}
       <Percentage>{formatPercentage(percentage)}</Percentage>
       <Amount showHiddenSection={!!showHidden}>
         <TokenAmount amount={amount} token={token} />
       </Amount>
-    </div>
+    </span>
   )
 }

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -6,12 +6,19 @@ import { safeTokenName } from 'utils'
 import { ProgressBar } from 'components/common/ProgressBar'
 import { OrderPriceDisplay } from '../OrderPriceDisplay'
 import { TokenAmount } from 'components/token/TokenAmount'
-import { SurplusComponent } from 'components/common/SurplusComponent'
+import { SurplusComponent, Percentage, Amount } from 'components/common/SurplusComponent'
 
 export type Props = {
   order: Order
   fullView?: boolean
+  lineBreak?: boolean
 }
+
+const StyledSurplusComponent = styled(SurplusComponent)`
+  display: flex;
+  flex-flow: column wrap;
+  gap: 1rem;
+`
 
 const Wrapper = styled.div`
   display: flex;
@@ -39,25 +46,34 @@ const Wrapper = styled.div`
 `
 
 const TableHeading = styled.div`
-  background: ${({ theme }): string => theme.tableRowBorder};
-  min-height: 11rem;
-  padding: 1.6rem;
-  display: flex;
-  gap: 2rem;
+  padding: 0 0 1rem;
+  display: grid;
+  grid-template-columns: minmax(min-content, auto) auto auto;
+  justify-content: flex-start;
+  gap: 1.6rem;
 
   ${media.mobile} {
-    flex-direction: column;
-    gap: 1rem;
+    display: flex;
+    flex-flow: column wrap;
   }
 
   .title {
     text-transform: uppercase;
+    font-weight: normal;
     font-size: 1.1rem;
+    letter-spacing: 0.1rem;
+    color: ${({ theme }): string => theme.grey};
+    margin: 0;
+    line-height: 1;
   }
 
-  .fillNumber {
+  .percentage,
+  ${Percentage} {
     font-size: 3.2rem;
-    margin: 1.5rem 0 1rem 0;
+    margin: 0;
+    line-height: 1;
+    letter-spacing: -0.2rem;
+    font-weight: ${({ theme }): string => theme.fontMedium};
     color: ${({ theme }): string => theme.green};
 
     ${media.mobile} {
@@ -65,25 +81,45 @@ const TableHeading = styled.div`
     }
   }
 
+  ${Amount} {
+    font-size: 1.2rem;
+    margin: 0;
+    line-height: 1;
+
+    > span {
+      white-space: nowrap;
+    }
+  }
+
   .priceNumber {
-    font-size: 2.2rem;
-    margin: 1rem 0;
+    font-size: 2.3rem;
+    margin: 0;
 
     ${media.mobile} {
       font-size: 1.8rem;
     }
 
-    span {
-      line-height: 1;
+    > span {
+      line-height: 1.2;
+      flex-flow: row wrap;
+      color: ${({ theme }): string => theme.grey};
+    }
+
+    > span > span:first-child {
+      color: ${({ theme }): string => theme.textPrimary1};
     }
   }
 `
 
 const TableHeadingContent = styled.div`
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 27rem;
+  flex-flow: column wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 1.4rem;
+  border-radius: 0.6rem;
+  background: ${({ theme }): string => theme.tableRowBorder};
+  padding: 2rem 1.8rem;
 
   ${media.mobile} {
     flex-direction: column;
@@ -91,44 +127,36 @@ const TableHeadingContent = styled.div`
 
   .progress-line {
     width: 100%;
-  }
-
-  &.surplus {
-    width: 20rem;
-  }
-
-  &.limit-price {
-    width: 38rem;
+    height: 0.4rem;
   }
 `
+
 const FilledContainer = styled.div`
   display: flex;
-  flex-direction: row;
-  align-items: end;
-  gap: 1rem;
-  margin-bottom: 1rem;
-`
+  flex-flow: column wrap;
+  gap: 1.4rem;
+  margin: 0;
 
-const OrderAssetsInfoWrapper = styled.span`
-  font-size: 12px;
-  line-height: normal;
-`
-
-const StyledSurplusComponent = styled(SurplusComponent)`
-  font-size: 2.2rem;
-  margin: 0.1rem 0;
-
-  ${media.mobile} {
-    font-size: 1.8rem;
+  > div {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    gap: 1.6rem;
   }
+`
 
-  span {
-    line-height: 1.1;
+const OrderAssetsInfoWrapper = styled.span<{ lineBreak?: boolean }>`
+  font-size: 1.2rem;
+  line-height: normal;
+
+  b:first-child {
+    display: ${({ lineBreak }): string => (lineBreak ? 'block' : 'inline')};
   }
 `
 
 export function FilledProgress(props: Props): JSX.Element {
   const {
+    lineBreak = false,
     fullView = false,
     order: {
       executedFeeAmount,
@@ -174,7 +202,7 @@ export function FilledProgress(props: Props): JSX.Element {
   const OrderAssetsInfo = (): JSX.Element => (
     <>
       {' '}
-      <OrderAssetsInfoWrapper>
+      <OrderAssetsInfoWrapper lineBreak={lineBreak}>
         <b>
           {/* Executed part (bought/sold tokens) */}
           <TokenAmount amount={filledAmountWithFee} token={mainToken} symbol={mainSymbol} />
@@ -203,13 +231,13 @@ export function FilledProgress(props: Props): JSX.Element {
     <TableHeading>
       <TableHeadingContent>
         <FilledContainer>
+          <p className="title">Filled</p>
           <div>
-            <p className="title">Filled</p>
-            <p className="fillNumber">{formattedPercentage}%</p>
+            <p className="percentage">{formattedPercentage}%</p>
+            <OrderAssetsInfo />
           </div>
-          <OrderAssetsInfo />
+          <ProgressBar showLabel={false} percentage={formattedPercentage} />
         </FilledContainer>
-        <ProgressBar showLabel={false} percentage={formattedPercentage} />
       </TableHeadingContent>
       <TableHeadingContent className="surplus">
         <p className="title">Total Surplus</p>

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -134,9 +134,7 @@ export function FilledProgress(props: Props): JSX.Element {
       executedFeeAmount,
       filledAmount,
       filledPercentage,
-      fullyFilled,
       kind,
-      feeAmount,
       sellAmount,
       buyAmount,
       executedBuyAmount,
@@ -155,7 +153,6 @@ export function FilledProgress(props: Props): JSX.Element {
 
   const mainToken = (isSell ? sellToken : buyToken) || null
   const mainAddress = isSell ? sellTokenAddress : buyTokenAddress
-  const mainAmount = isSell ? sellAmount.plus(feeAmount) : buyAmount
   const swappedToken = (isSell ? buyToken : sellToken) || null
   const swappedAddress = isSell ? buyTokenAddress : sellTokenAddress
   const swappedAmount = isSell ? executedBuyAmount : executedSellAmount
@@ -182,15 +179,6 @@ export function FilledProgress(props: Props): JSX.Element {
           {/* Executed part (bought/sold tokens) */}
           <TokenAmount amount={filledAmountWithFee} token={mainToken} symbol={mainSymbol} />
         </b>{' '}
-        {!fullyFilled && (
-          // Show the total amount to buy/sell. Only for orders that are not 100% executed
-          <>
-            of{' '}
-            <b>
-              <TokenAmount amount={mainAmount} token={mainToken} symbol={mainSymbol} />
-            </b>{' '}
-          </>
-        )}
         {action}{' '}
         {touched && (
           // Executed part of the trade:

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -6,6 +6,7 @@ import { safeTokenName } from 'utils'
 import { ProgressBar } from 'components/common/ProgressBar'
 import { OrderPriceDisplay } from '../OrderPriceDisplay'
 import { TokenAmount } from 'components/token/TokenAmount'
+import { SurplusComponent } from 'components/common/SurplusComponent'
 
 export type Props = {
   order: Order
@@ -92,6 +93,10 @@ const TableHeadingContent = styled.div`
     width: 100%;
   }
 
+  &.surplus {
+    width: 20rem;
+  }
+
   &.limit-price {
     width: 38rem;
   }
@@ -107,6 +112,19 @@ const FilledContainer = styled.div`
 const OrderAssetsInfoWrapper = styled.span`
   font-size: 12px;
   line-height: normal;
+`
+
+const StyledSurplusComponent = styled(SurplusComponent)`
+  font-size: 2.2rem;
+  margin: 0.1rem 0;
+
+  ${media.mobile} {
+    font-size: 1.8rem;
+  }
+
+  span {
+    line-height: 1.1;
+  }
 `
 
 export function FilledProgress(props: Props): JSX.Element {
@@ -127,6 +145,8 @@ export function FilledProgress(props: Props): JSX.Element {
       sellToken,
       buyTokenAddress,
       sellTokenAddress,
+      surplusAmount,
+      surplusPercentage,
     },
   } = props
 
@@ -150,6 +170,10 @@ export function FilledProgress(props: Props): JSX.Element {
   const swappedSymbol = swappedToken ? safeTokenName(swappedToken) : swappedAddress
   // In case the token object is empty, display the raw amount (`decimals || 0` part)
   const formattedPercentage = filledPercentage.times('100').decimalPlaces(2).toString()
+
+  const surplus = { amount: surplusAmount, percentage: surplusPercentage }
+  const surplusToken = (isSell ? buyToken : sellToken) || null
+
   const OrderAssetsInfo = (): JSX.Element => (
     <>
       {' '}
@@ -198,6 +222,10 @@ export function FilledProgress(props: Props): JSX.Element {
           <OrderAssetsInfo />
         </FilledContainer>
         <ProgressBar showLabel={false} percentage={formattedPercentage} />
+      </TableHeadingContent>
+      <TableHeadingContent className="surplus">
+        <p className="title">Total Surplus</p>
+        <StyledSurplusComponent surplus={surplus} token={surplusToken} showHidden />
       </TableHeadingContent>
       <TableHeadingContent className="limit-price">
         <p className="title">Limit Price</p>

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExchangeAlt, faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
+import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
 import { useNetworkId } from 'state/network'
 import { Order, Trade } from 'api/operator'
 import { abbreviateString } from 'utils'
@@ -17,7 +16,6 @@ import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import { DateDisplay } from 'components/common/DateDisplay'
 import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import { TableState } from 'apps/explorer/components/TokensTableWidget/useTable'
-import { LinkButton } from '../DetailsTable'
 import { FilledProgress } from '../FilledProgress'
 import { TokenAmount } from 'components/token/TokenAmount'
 import Icon from 'components/Icon'
@@ -74,7 +72,7 @@ const Wrapper = styled(StyledUserDetailsTable)`
 
   > thead > tr,
   > tbody > tr {
-    grid-template-columns: 4fr 2fr 3fr 3fr 3.5fr 3fr 4fr;
+    grid-template-columns: 3fr 3fr 3fr 3fr 3.5fr 3fr;
   }
 
   > tbody > tr > td:nth-child(8),
@@ -203,16 +201,6 @@ const MainWrapper = styled.div`
   width: 100%;
 `
 
-const StyledLinkButton = styled(LinkButton)`
-  margin-left: 0;
-
-  ${media.mediumDown} {
-    min-width: auto;
-    font-size: 12px;
-    padding: 4px 8px;
-  }
-`
-
 const StyledShimmerBar = styled(ShimmerBar)`
   min-height: 20px;
   min-width: 100px;
@@ -320,15 +308,6 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) =
           {executionTime ? <DateDisplay date={executionTime} showIcon={true} /> : <StyledShimmerBar />}
         </HeaderValue>
       </td>
-      <td>
-        <HeaderTitle></HeaderTitle>
-        <HeaderValue>
-          <StyledLinkButton to={`/tx/${txHash}/?tab=graph`}>
-            <FontAwesomeIcon icon={faProjectDiagram} />
-            View batch graph
-          </StyledLinkButton>
-        </HeaderValue>
-      </td>
     </tr>
   )
 }
@@ -384,7 +363,6 @@ const FillsTable: React.FC<Props> = (props) => {
             <th>Buy amount</th>
             <th>Execution price {invertButton}</th>
             <th>Execution time</th>
-            <th></th>
           </tr>
         }
         body={tradeItems(trades)}

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -299,15 +299,15 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) =
         </HeaderValue>
       </td>
       <td>
-        <HeaderTitle>Buy amount</HeaderTitle>
-        <HeaderValue>
-          <TokenAmount amount={buyAmount} token={buyToken} />
-        </HeaderValue>
-      </td>
-      <td>
         <HeaderTitle>Sell amount</HeaderTitle>
         <HeaderValue>
           <TokenAmount amount={sellAmount} token={sellToken} />
+        </HeaderValue>
+      </td>
+      <td>
+        <HeaderTitle>Buy amount</HeaderTitle>
+        <HeaderValue>
+          <TokenAmount amount={buyAmount} token={buyToken} />
         </HeaderValue>
       </td>
       <td>
@@ -380,8 +380,8 @@ const FillsTable: React.FC<Props> = (props) => {
           <tr>
             <th>Tx hash</th>
             <th>Surplus</th>
-            <th>Buy amount</th>
             <th>Sell amount</th>
+            <th>Buy amount</th>
             <th>Execution price {invertButton}</th>
             <th>Execution time</th>
             <th></th>

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
 import { useNetworkId } from 'state/network'
 import { Order, Trade } from 'api/operator'
@@ -19,6 +19,7 @@ import { TableState } from 'apps/explorer/components/TokensTableWidget/useTable'
 import { FilledProgress } from '../FilledProgress'
 import { TokenAmount } from 'components/token/TokenAmount'
 import Icon from 'components/Icon'
+import { faArrowAltCircleUp as faIcon } from '@fortawesome/free-regular-svg-icons'
 import { calculatePrice, TokenErc20 } from '@gnosis.pm/dex-js'
 import { TEN_BIG_NUMBER } from 'const'
 import BigNumber from 'bignumber.js'
@@ -34,9 +35,6 @@ const Wrapper = styled(StyledUserDetailsTable)`
   }
 
   > tbody {
-    min-height: 37rem;
-    border-bottom: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
-
     > tr {
       min-height: 7.4rem;
 
@@ -188,6 +186,9 @@ const HeaderTitle = styled.span`
 `
 const HeaderValue = styled.span<{ captionColor?: 'green' | 'red1' | 'grey' }>`
   color: ${({ theme, captionColor }): string => (captionColor ? theme[captionColor] : theme.textPrimary1)};
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
 
   ${media.mobile} {
     flex-wrap: wrap;
@@ -238,6 +239,7 @@ function calculateExecutionPrice(
 }
 
 const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) => {
+  const theme = useTheme()
   const network = useNetworkId() || undefined
   const {
     txHash,
@@ -295,11 +297,17 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) =
       <td>
         <HeaderTitle>Surplus</HeaderTitle>
         <HeaderValue>
-          {surplus ? <SurplusComponent surplus={surplus} token={surplusToken} showHidden /> : '-'}
+          {surplus ? (
+            <SurplusComponent icon={faIcon} iconColor={theme.green} surplus={surplus} token={surplusToken} showHidden />
+          ) : (
+            '-'
+          )}
         </HeaderValue>
       </td>
       <td>
-        <HeaderTitle>Execution price {invertButton}</HeaderTitle>
+        <HeaderTitle>
+          <span>Execution price</span> {invertButton}
+        </HeaderTitle>
         <HeaderValue>{executionPrice && <TokenAmount amount={executionPrice} token={executionToken} />}</HeaderValue>
       </td>
       <td>
@@ -352,7 +360,7 @@ const FillsTable: React.FC<Props> = (props) => {
 
   return (
     <MainWrapper>
-      {order && <FilledProgress fullView order={order} />}
+      {order && <FilledProgress lineBreak fullView order={order} />}
       <Wrapper
         showBorderTable={showBorderTable}
         header={
@@ -361,7 +369,9 @@ const FillsTable: React.FC<Props> = (props) => {
             <th>Sell amount</th>
             <th>Buy amount</th>
             <th>Surplus</th>
-            <th>Execution price {invertButton}</th>
+            <th>
+              <span>Execution price</span> {invertButton}
+            </th>
             <th>Execution time</th>
           </tr>
         }

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -281,12 +281,6 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) =
         </HeaderValue>
       </td>
       <td>
-        <HeaderTitle>Surplus</HeaderTitle>
-        <HeaderValue>
-          {surplus ? <SurplusComponent surplus={surplus} token={surplusToken} showHidden /> : '-'}
-        </HeaderValue>
-      </td>
-      <td>
         <HeaderTitle>Sell amount</HeaderTitle>
         <HeaderValue>
           <TokenAmount amount={sellAmount} token={sellToken} />
@@ -296,6 +290,12 @@ const RowFill: React.FC<RowProps> = ({ trade, isPriceInverted, invertButton }) =
         <HeaderTitle>Buy amount</HeaderTitle>
         <HeaderValue>
           <TokenAmount amount={buyAmount} token={buyToken} />
+        </HeaderValue>
+      </td>
+      <td>
+        <HeaderTitle>Surplus</HeaderTitle>
+        <HeaderValue>
+          {surplus ? <SurplusComponent surplus={surplus} token={surplusToken} showHidden /> : '-'}
         </HeaderValue>
       </td>
       <td>
@@ -358,9 +358,9 @@ const FillsTable: React.FC<Props> = (props) => {
         header={
           <tr>
             <th>Tx hash</th>
-            <th>Surplus</th>
             <th>Sell amount</th>
             <th>Buy amount</th>
+            <th>Surplus</th>
             <th>Execution price {invertButton}</th>
             <th>Execution time</th>
           </tr>

--- a/src/components/orders/OrderPriceDisplay/index.tsx
+++ b/src/components/orders/OrderPriceDisplay/index.tsx
@@ -15,6 +15,21 @@ import {
 const Wrapper = styled.span`
   display: flex;
   align-items: center;
+  justify-content: flex-start;
+
+  > span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  > span:first-child {
+    margin: 0 0.5rem 0 0;
+  }
+
+  > span:last-child {
+    white-space: nowrap;
+  }
 `
 
 export type Props = {
@@ -58,8 +73,13 @@ export function OrderPriceDisplay(props: Props): JSX.Element {
 
   return (
     <Wrapper>
-      {formattedPrice} {quoteSymbol} for {baseSymbol}
-      {showInvertButton && <Icon icon={faExchangeAlt} onClick={invert} />}
+      <span>
+        {formattedPrice} {quoteSymbol}
+      </span>
+      <span>
+        for {baseSymbol}
+        {showInvertButton && <Icon icon={faExchangeAlt} onClick={invert} />}
+      </span>
     </Wrapper>
   )
 }

--- a/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -4,7 +4,6 @@ import styled, { css, useTheme, FlattenSimpleInterpolation } from 'styled-compon
 import { Order } from 'api/operator'
 
 import { BaseIconTooltipOnHover } from 'components/Tooltip'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowAltCircleUp as faIcon } from '@fortawesome/free-regular-svg-icons'
 import BigNumber from 'bignumber.js'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
@@ -53,16 +52,6 @@ export function OrderSurplusDisplay(props: Props): JSX.Element | null {
   return <Wrapper surplus={surplus} token={surplus.surplusToken} showHidden />
 }
 
-const IconWrapper = styled(FontAwesomeIcon)`
-  padding: 0.6rem;
-  margin: -0.6rem 0 -0.6rem -0.6rem;
-  box-sizing: content-box;
-
-  :hover {
-    cursor: pointer;
-  }
-`
-
 const HiddenSection = styled.span<{ showHiddenSection: boolean; strechHiddenSection?: boolean }>`
   display: ${({ showHiddenSection }): string => (showHiddenSection ? 'flex' : 'none')};
   ${({ strechHiddenSection }): FlattenSimpleInterpolation | false | undefined =>
@@ -98,10 +87,13 @@ export function OrderSurplusTooltipDisplay({
     <BaseIconTooltipOnHover
       tooltip={<TokenAmount amount={surplus.amount} token={surplus.surplusToken} />}
       targetContent={
-        <>
-          <IconWrapper icon={faIcon} color={theme.green} />
-          <SurplusComponent surplus={surplus} token={surplus.surplusToken} showHidden={showHiddenSection} />
-        </>
+        <SurplusComponent
+          surplus={surplus}
+          token={surplus.surplusToken}
+          showHidden={showHiddenSection}
+          icon={faIcon}
+          iconColor={theme.green}
+        />
       }
     />
   )

--- a/src/components/token/TokenTable/index.tsx
+++ b/src/components/token/TokenTable/index.tsx
@@ -28,8 +28,6 @@ const Wrapper = styled(StyledUserDetailsTable)`
     }
   }
   > tbody {
-    min-height: 37rem;
-    border-bottom: 0.1rem solid ${({ theme }): string => theme.tableRowBorder};
     > tr {
       min-height: 7.4rem;
       &.header-row {


### PR DESCRIPTION
# Summary

Addressing follow ups raised on https://github.com/cowprotocol/explorer/pull/440#pullrequestreview-1377794272

![image](https://user-images.githubusercontent.com/43217/231218980-082b7500-15cb-49a0-b4d0-0a123bd64941.png)


1. Inverted sell and buy amount position, now sell amount comes first
2. Removed batch viewer link
3. Moved surplus column after buy amount
4. Added surplus to fills table header
5. Remove the `of <full amount>` from progress

# To Test

1. Check out this order `0x62baf4be8adec4766d26a2169999cc170c3ead90ae11a28d658e6d75edc05b185b0abe214ab7875562adee331deff0fe1912fe42644d2bb7`