### PR TITLE
Partial fills table styling

### DIFF
--- a/src/components/common/SurplusComponent/index.tsx
+++ b/src/components/common/SurplusComponent/index.tsx
@@ -4,11 +4,11 @@ import { formatPercentage, Surplus } from 'utils'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 import { TokenAmount } from 'components/token/TokenAmount'
 
-const Percentage = styled.span`
+export const Percentage = styled.span`
   color: ${({ theme }): string => theme.green};
 `
 
-const Amount = styled.span<{ showHiddenSection: boolean; strechHiddenSection?: boolean }>`
+export const Amount = styled.span<{ showHiddenSection: boolean; strechHiddenSection?: boolean }>`
   display: ${({ showHiddenSection }): string => (showHiddenSection ? 'flex' : 'none')};
   ${({ strechHiddenSection }): FlattenSimpleInterpolation | false | undefined =>
     strechHiddenSection &&

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -6,12 +6,18 @@ import { safeTokenName } from 'utils'
 import { ProgressBar } from 'components/common/ProgressBar'
 import { OrderPriceDisplay } from '../OrderPriceDisplay'
 import { TokenAmount } from 'components/token/TokenAmount'
-import { SurplusComponent } from 'components/common/SurplusComponent'
+import { SurplusComponent, Percentage, Amount } from 'components/common/SurplusComponent'
 
 export type Props = {
   order: Order
   fullView?: boolean
 }
+
+const StyledSurplusComponent = styled(SurplusComponent)`
+  display: flex;
+  flex-flow: column wrap;
+  gap: 1rem;
+`
 
 const Wrapper = styled.div`
   display: flex;
@@ -39,25 +45,34 @@ const Wrapper = styled.div`
 `
 
 const TableHeading = styled.div`
-  background: ${({ theme }): string => theme.tableRowBorder};
-  min-height: 11rem;
-  padding: 1.6rem;
-  display: flex;
-  gap: 2rem;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: minmax(min-content, auto) auto auto;
+  justify-content: flex-start;
+  gap: 1.6rem;
 
   ${media.mobile} {
-    flex-direction: column;
-    gap: 1rem;
+    display: flex;
+    flex-flow: column wrap;
   }
 
   .title {
     text-transform: uppercase;
+    font-weight: normal;
     font-size: 1.1rem;
+    letter-spacing: 0.1rem;
+    color: ${({ theme }): string => theme.grey};
+    margin: 0;
+    line-height: 1;
   }
 
-  .fillNumber {
+  .percentage,
+  ${Percentage} {
     font-size: 3.2rem;
-    margin: 1.5rem 0 1rem 0;
+    margin: 0;
+    line-height: 1;
+    letter-spacing: -0.2rem;
+    font-weight: ${({ theme }): string => theme.fontMedium};
     color: ${({ theme }): string => theme.green};
 
     ${media.mobile} {
@@ -65,25 +80,45 @@ const TableHeading = styled.div`
     }
   }
 
+  ${Amount} {
+    font-size: 1.2rem;
+    margin: 0;
+    line-height: 1;
+
+    > span {
+      white-space: nowrap;
+    }
+  }
+
   .priceNumber {
-    font-size: 2.2rem;
-    margin: 1rem 0;
+    font-size: 2.3rem;
+    margin: 0;
 
     ${media.mobile} {
       font-size: 1.8rem;
     }
 
-    span {
-      line-height: 1;
+    > span {
+      line-height: 1.2;
+      flex-flow: row wrap;
+      color: ${({ theme }): string => theme.grey};
+    }
+
+    > span > span:first-child {
+      color: ${({ theme }): string => theme.textPrimary1};
     }
   }
 `
 
 const TableHeadingContent = styled.div`
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 27rem;
+  flex-flow: column wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 1.4rem;
+  border-radius: 0.6rem;
+  background: ${({ theme }): string => theme.tableRowBorder};
+  padding: 2rem 1.8rem;
 
   ${media.mobile} {
     flex-direction: column;
@@ -91,39 +126,30 @@ const TableHeadingContent = styled.div`
 
   .progress-line {
     width: 100%;
-  }
-
-  &.surplus {
-    width: 20rem;
-  }
-
-  &.limit-price {
-    width: 38rem;
+    height: 0.4rem;
   }
 `
+
 const FilledContainer = styled.div`
   display: flex;
-  flex-direction: row;
-  align-items: end;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  flex-flow: column wrap;
+  gap: 1.4rem;
+  margin: 0;
+
+  > div {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    gap: 1.6rem;
+  }
 `
 
 const OrderAssetsInfoWrapper = styled.span`
-  font-size: 12px;
+  font-size: 1.2rem;
   line-height: normal;
-`
 
-const StyledSurplusComponent = styled(SurplusComponent)`
-  font-size: 2.2rem;
-  margin: 0.1rem 0;
-
-  ${media.mobile} {
-    font-size: 1.8rem;
-  }
-
-  span {
-    line-height: 1.1;
+  b:first-child {
+    display: block;
   }
 `
 
@@ -203,13 +229,13 @@ export function FilledProgress(props: Props): JSX.Element {
     <TableHeading>
       <TableHeadingContent>
         <FilledContainer>
+          <p className="title">Filled</p>
           <div>
-            <p className="title">Filled</p>
-            <p className="fillNumber">{formattedPercentage}%</p>
+            <p className="percentage">{formattedPercentage}%</p>
+            <OrderAssetsInfo />
           </div>
-          <OrderAssetsInfo />
+          <ProgressBar showLabel={false} percentage={formattedPercentage} />
         </FilledContainer>
-        <ProgressBar showLabel={false} percentage={formattedPercentage} />
       </TableHeadingContent>
       <TableHeadingContent className="surplus">
         <p className="title">Total Surplus</p>

--- a/src/components/orders/OrderPriceDisplay/index.tsx
+++ b/src/components/orders/OrderPriceDisplay/index.tsx
@@ -58,7 +58,10 @@ export function OrderPriceDisplay(props: Props): JSX.Element {
 
   return (
     <Wrapper>
-      {formattedPrice} {quoteSymbol} for {baseSymbol}
+      <span>
+        {formattedPrice} {quoteSymbol}&nbsp;
+      </span>{' '}
+      for {baseSymbol}
       {showInvertButton && <Icon icon={faExchangeAlt} onClick={invert} />}
     </Wrapper>
   )


### PR DESCRIPTION
# Summary

- Styles the partial fills table header elements.
- Based on https://github.com/cowprotocol/explorer/pull/442

## Before / After
<img width="1000" alt="Screenshot 2023-04-11 at 23 10 12" src="https://user-images.githubusercontent.com/31534717/231289775-15d0a8f2-6015-44bb-8240-3cdb9027f6e9.png"><img width="1000" alt="Screenshot 2023-04-11 at 23 09 43" src="https://user-images.githubusercontent.com/31534717/231289961-ab8d6f59-a4cc-443c-970f-ce26c2ca6389.png">


## Before / After (mobile)
<img width="400" alt="Screenshot 2023-04-11 at 23 10 45" src="https://user-images.githubusercontent.com/31534717/231290144-443f7526-bda4-413a-ba03-f9415f9f205b.png"><img width="400" alt="Screenshot 2023-04-11 at 23 11 27" src="https://user-images.githubusercontent.com/31534717/231290163-b1dd6541-e6e3-40c3-a3e9-e9c8fe6017b7.png">
