### PR TITLE
fix: show only trades belonging to the current page on fills tab

### DIFF
--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -327,7 +327,7 @@ const FillsTable: React.FC<Props> = (props) => {
 
   const invertButton = <Icon icon={faExchangeAlt} onClick={invertPrice} />
 
-  const shownTrades = useMemo(() => {
+  const currentPageTrades = useMemo(() => {
     return trades?.slice(tableState.pageOffset, tableState.pageOffset + tableState.pageSize)
   }, [tableState.pageOffset, tableState.pageSize, trades])
 
@@ -378,7 +378,7 @@ const FillsTable: React.FC<Props> = (props) => {
             <th>Execution time</th>
           </tr>
         }
-        body={tradeItems(shownTrades)}
+        body={tradeItems(currentPageTrades)}
       />
     </MainWrapper>
   )

--- a/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/src/components/orders/OrderDetails/FillsTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled, { useTheme } from 'styled-components'
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
 import { useNetworkId } from 'state/network'
@@ -327,6 +327,10 @@ const FillsTable: React.FC<Props> = (props) => {
 
   const invertButton = <Icon icon={faExchangeAlt} onClick={invertPrice} />
 
+  const shownTrades = useMemo(() => {
+    return trades?.slice(tableState.pageOffset, tableState.pageOffset + tableState.pageSize)
+  }, [tableState.pageOffset, tableState.pageSize, trades])
+
   const tradeItems = (items: Trade[] | undefined): JSX.Element => {
     if (!items || items.length === 0) {
       return (
@@ -374,7 +378,7 @@ const FillsTable: React.FC<Props> = (props) => {
             <th>Execution time</th>
           </tr>
         }
-        body={tradeItems(trades)}
+        body={tradeItems(shownTrades)}
       />
     </MainWrapper>
   )


### PR DESCRIPTION
# Summary

Closes #445 

Fills tab list shows only trades from the current page

# To Test

1. Load an order with >10 trades, such as `0x9f5f18111f22b1912bd8f291b753a6fd85e04cd9f05111520f6108fc052716279fa3c00a92ec5f96b1ad2527ab41b3932efeda58643ff3da`
2. Go to fills tab
* It should show more than 1 page
![image](https://user-images.githubusercontent.com/43217/233676638-aa5b52af-6083-4034-9294-a86ed6f15d50.png)
* The list should be limited by default to 10 items
* There should be 10 rows in the table
3. Go to the next page
* It should show the next trades, up to 10 in the page