### PR TITLE
448/avg execution price card

### DIFF
--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -243,10 +243,6 @@ export function FilledProgress(props: Props): JSX.Element {
           <ProgressBar showLabel={false} percentage={formattedPercentage} />
         </FilledContainer>
       </TableHeadingContent>
-      <TableHeadingContent className="surplus">
-        <p className="title">Total Surplus</p>
-        <StyledSurplusComponent surplus={surplus} token={surplusToken} showHidden />
-      </TableHeadingContent>
       <TableHeadingContent>
         <p className="title">Avg. Execution Price</p>
         <p className="priceNumber">
@@ -262,6 +258,10 @@ export function FilledProgress(props: Props): JSX.Element {
             />
           )}
         </p>
+      </TableHeadingContent>
+      <TableHeadingContent className="surplus">
+        <p className="title">Total Surplus</p>
+        <StyledSurplusComponent surplus={surplus} token={surplusToken} showHidden />
       </TableHeadingContent>
       <TableHeadingContent>
         <p className="title">Limit Price</p>

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -50,7 +50,7 @@ const Wrapper = styled.div`
 const TableHeading = styled.div`
   padding: 0 0 1rem;
   display: grid;
-  grid-template-columns: minmax(min-content, auto) auto auto;
+  grid-template-columns: minmax(min-content, auto) auto auto auto;
   justify-content: flex-start;
   gap: 1.6rem;
 

--- a/src/components/orders/FilledProgress/index.tsx
+++ b/src/components/orders/FilledProgress/index.tsx
@@ -247,7 +247,23 @@ export function FilledProgress(props: Props): JSX.Element {
         <p className="title">Total Surplus</p>
         <StyledSurplusComponent surplus={surplus} token={surplusToken} showHidden />
       </TableHeadingContent>
-      <TableHeadingContent className="limit-price">
+      <TableHeadingContent>
+        <p className="title">Avg. Execution Price</p>
+        <p className="priceNumber">
+          {buyToken && sellToken && (
+            <OrderPriceDisplay
+              buyAmount={executedBuyAmount}
+              buyToken={buyToken}
+              sellAmount={executedSellAmount}
+              sellToken={sellToken}
+              showInvertButton
+              isPriceInverted={isPriceInverted}
+              invertPrice={invertPrice}
+            />
+          )}
+        </p>
+      </TableHeadingContent>
+      <TableHeadingContent>
         <p className="title">Limit Price</p>
         <p className="priceNumber">
           {buyToken && sellToken && (


### PR DESCRIPTION
# Summary

Closes #448 

![image](https://user-images.githubusercontent.com/43217/235734081-3ce0a248-8477-404b-b1db-a3f5bbbccac4.png)

# To Test

1. Check a order with multiple fills such as `0x62baf4be8adec4766d26a2169999cc170c3ead90ae11a28d658e6d75edc05b185b0abe214ab7875562adee331deff0fe1912fe42644d2bb7`
2. It should have a new card with the avg. execution price