### PR TITLE
chore: update @cowprotocol/cow-sdk to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "v0.1.0-alpha.0",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^2.0.0",
+    "@cowprotocol/cow-sdk": "^2.0.6",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/src/api/operator/operatorApi.ts
+++ b/src/api/operator/operatorApi.ts
@@ -133,12 +133,12 @@ export async function getTrades(
     orderId?: UID
   } & WithNetworkId,
 ): Promise<RawTrade[]> {
-  const { networkId, owner, orderId } = params
-  console.log(`[getTrades] Fetching trades on network ${networkId} with filters`, { owner, orderId })
+  const { networkId, owner, orderId: orderUid } = params
+  console.log(`[getTrades] Fetching trades on network ${networkId} with filters`, { owner, orderUid })
 
-  const tradesPromise = orderBookSDK.getTrades({ owner, orderId }, { chainId: networkId })
+  const tradesPromise = orderBookSDK.getTrades({ owner, orderUid }, { chainId: networkId })
   const tradesPromiseBarn = orderBookSDK
-    .getTrades({ owner, orderId }, { chainId: networkId, env: 'staging' })
+    .getTrades({ owner, orderUid }, { chainId: networkId, env: 'staging' })
     .catch((error) => {
       console.error('[getTrades] Error getting the trades for Barn', params, error)
       return []

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,17 +1319,17 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.4.0.tgz#e93e5f25aac76feeaa348fa57231903274676247"
   integrity sha512-XLs3SlPmXD4lbiWIO7mxxuCn1eE5isuO6EUlE1cj17HqN/wukDAN0xXYPx6umOH/XdjGS33miMiPHELEyY9siw==
 
-"@cowprotocol/cow-sdk@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.0.1.tgz#9467f8538048373d78dc355e97b878164e4be834"
-  integrity sha512-irfQTh0z6earB06lsX+rG6fa6pQqRSnyivnma/ZNPA+uT7AisZKlslbW2mgaKXkqWygZFnfL9UUz5dQMwTFMCQ==
+"@cowprotocol/cow-sdk@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.0.6.tgz#06a0f3a8250f45007f7a0026c4595ece993bbfc8"
+  integrity sha512-p+a50tRDwcEiuKJYPCAHP6yakke/NAwW+MuPDslKTPO1tUl9jvRSe3ercW+zUmTgZyLLZeE+yjzeyJwFD85amg==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
-    axios "^1.3.4"
+    "@ethersproject/abstract-signer" "^5.7.0"
     cross-fetch "^3.1.5"
-    ethers "^5.7.2"
-    graphql "^16.3.0"
+    exponential-backoff "^3.1.1"
     graphql-request "^4.3.0"
+    limiter "^2.1.0"
 
 "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"
@@ -5671,15 +5671,6 @@ axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
-axios@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
-  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 babel-jest@^26.1.0, babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -9308,7 +9299,7 @@ ethereumjs-wallet@^1.0.1:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@^5.0.26, ethers@^5.7.2:
+ethers@^5.0.26:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -9551,6 +9542,11 @@ expect@^26.6.2:
     jest-matcher-utils "^26.6.2"
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
+
+exponential-backoff@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
+  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
 
 express@^4.14.0, express@^4.16.3, express@^4.17.1:
   version "4.18.2"
@@ -10080,7 +10076,7 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
-follow-redirects@^1.14.9, follow-redirects@^1.15.0:
+follow-redirects@^1.14.9:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -10787,7 +10783,7 @@ graphql-tag@^2.12.6:
   dependencies:
     tslib "^2.1.0"
 
-graphql@^16.3.0, graphql@^16.5.0:
+graphql@^16.5.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
@@ -13316,6 +13312,11 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
+just-performance@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/just-performance/-/just-performance-4.3.0.tgz#cc2bc8c9227f09e97b6b1df4cd0de2df7ae16db1"
+  integrity sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q==
+
 keccak@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.1.tgz#ae30a0e94dbe43414f741375cff6d64c8bea0bff"
@@ -13502,6 +13503,13 @@ lightweight-charts@^3.8.0:
   integrity sha512-7yFGnYuE1RjRJG9RwUTBz5wvF1QtjBOSW4FFlikr8Dh+/TDNt4ci+HsWSYmStgQUpawpvkCJ3j5/W25GppGj9Q==
   dependencies:
     fancy-canvas "0.2.2"
+
+limiter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-2.1.0.tgz#d38d7c5b63729bb84fb0c4d8594b7e955a5182a2"
+  integrity sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw==
+  dependencies:
+    just-performance "4.3.0"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"


### PR DESCRIPTION
# Summary

There was a problem with `peerDependencies` in SDK, the fix:
https://github.com/cowprotocol/cow-sdk/commit/7543993c778d8151421e40d3adbba3a74c6ea9ea

And a problem with `getTrades` merhod, the fix:
https://github.com/cowprotocol/cow-sdk/commit/5688fee76a4bdd6f68bbd96691c10f302c451685