### PR TITLE
Ipfs gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ MOCK=true
 # Enables autoconnect for mock mode (default = true)
 AUTOCONNECT=true
 
+# Public IPFS gateway
+IPFS_READ_URI=https://cloudflare-ipfs.com/ipfs
+
 # Sentry
 #REACT_APP_SENTRY_DSN='https://<url>'
 #REACT_APP_SENTRY_TRACES_SAMPLE_RATE="1.0"

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ MOCK=true
 AUTOCONNECT=true
 
 # Public IPFS gateway
-IPFS_READ_URI=https://cloudflare-ipfs.com/ipfs
+REACT_APP_IPFS_READ_URI=https://cloudflare-ipfs.com/ipfs
 
 # Sentry
 #REACT_APP_SENTRY_DSN='https://<url>'

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Build Project Artifacts
         run: >
+          REACT_APP_IPFS_READ_URI=${{ secrets.REACT_APP_IPFS_READ_URI }}
           REACT_APP_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
           REACT_APP_SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
           GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_ANALYTICS_ID }}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "",
   "dependencies": {
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/app-data": "v0.1.0-alpha.0",
+    "@cowprotocol/app-data": "v0.1.0",
     "@cowprotocol/contracts": "1.3.1",
     "@cowprotocol/cow-sdk": "^2.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/src/apps/explorer/pages/AppData/config.tsx
+++ b/src/apps/explorer/pages/AppData/config.tsx
@@ -116,6 +116,7 @@ const deleteAllPropertiesByName = (schema: JSONSchema7, property: string): void 
     deletePropertyPath(schema, property)
   }
   if (!schema.properties) return
+
   for (const field in schema.properties) {
     deleteAllPropertiesByName(schema.properties[field] as JSONSchema7, property)
   }
@@ -138,7 +139,15 @@ export const deletePropertyPath = (obj: any, path: any): void => {
     }
   }
 
-  delete obj[path.pop()]
+  const propName = path.pop()
+  if (!propName) {
+    return
+  }
+
+  const propConfigurable = Object.getOwnPropertyDescriptor(obj, propName)?.configurable || false
+  if (propConfigurable) {
+    delete obj[propName]
+  }
 }
 
 const quoteDependencies = {

--- a/src/const.ts
+++ b/src/const.ts
@@ -180,7 +180,7 @@ export const NATIVE_TOKEN_PER_NETWORK: Record<string, TokenErc20> = {
 
 export const NO_REDIRECT_HOME_ROUTES: Array<string> = ['/address']
 
-export const TENDERLY_API_URL = 'https://cloudflare-ipfs.com/ipfs/QmUVYe2SGZQYf2NJrbGPeSZTMGSC5mEqaMXjM741P8TeX2'
+export const TENDERLY_API_URL = 'https://api.tenderly.co/api/v1/public-contract'
 export const DEFAULT_IPFS_READ_URI = process.env.IPFS_READ_URI || 'https://cloudflare-ipfs.com/ipfs'
 export const IPFS_INVALID_APP_IDS = [
   '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/src/const.ts
+++ b/src/const.ts
@@ -181,7 +181,7 @@ export const NATIVE_TOKEN_PER_NETWORK: Record<string, TokenErc20> = {
 export const NO_REDIRECT_HOME_ROUTES: Array<string> = ['/address']
 
 export const TENDERLY_API_URL = 'https://api.tenderly.co/api/v1/public-contract'
-export const DEFAULT_IPFS_READ_URI = process.env.IPFS_READ_URI || 'https://cloudflare-ipfs.com/ipfs'
+export const DEFAULT_IPFS_READ_URI = process.env.REACT_APP_IPFS_READ_URI || 'https://cloudflare-ipfs.com/ipfs'
 export const IPFS_INVALID_APP_IDS = [
   '0x0000000000000000000000000000000000000000000000000000000000000000',
   '0x0000000000000000000000000000000000000000000000000000000000000001',

--- a/src/const.ts
+++ b/src/const.ts
@@ -180,8 +180,8 @@ export const NATIVE_TOKEN_PER_NETWORK: Record<string, TokenErc20> = {
 
 export const NO_REDIRECT_HOME_ROUTES: Array<string> = ['/address']
 
-export const TENDERLY_API_URL = 'https://api.tenderly.co/api/v1/public-contract'
-export const DEFAULT_IPFS_READ_URI = 'https://gnosis.mypinata.cloud/ipfs'
+export const TENDERLY_API_URL = 'https://cloudflare-ipfs.com/ipfs/QmUVYe2SGZQYf2NJrbGPeSZTMGSC5mEqaMXjM741P8TeX2'
+export const DEFAULT_IPFS_READ_URI = process.env.IPFS_READ_URI || 'https://cloudflare-ipfs.com/ipfs'
 export const IPFS_INVALID_APP_IDS = [
   '0x0000000000000000000000000000000000000000000000000000000000000000',
   '0x0000000000000000000000000000000000000000000000000000000000000001',

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { AnyAppDataDocVersion } from '@cowprotocol/app-data'
 import { useNetworkId } from 'state/network'
 import { metadataApiSDK } from 'cowSdk'
+import { DEFAULT_IPFS_READ_URI } from 'const'
 
 export const useAppData = (
   appDataHash: string,
@@ -30,7 +31,7 @@ export const useAppData = (
 }
 
 export const getDecodedAppData = (appDataHash: string): Promise<void | AnyAppDataDocVersion> => {
-  return metadataApiSDK.decodeAppData(appDataHash)
+  return metadataApiSDK.decodeAppData(appDataHash, DEFAULT_IPFS_READ_URI)
 }
 
 export const getCidHashFromAppData = (appDataHash: string): Promise<string | void> => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,8 @@ const EXPLORER_APP = {
     OPERATOR_URL_PROD_GOERLI: 'https://api.cow.fi/goerli/api',
     OPERATOR_URL_PROD_XDAI: 'https://api.cow.fi/xdai/api',
 
+    REACT_APP_IPFS_READ_URI: process.env.REACT_APP_IPFS_READ_URI,
+
     GOOGLE_ANALYTICS_ID: undefined,
     REACT_APP_SENTRY_DSN: undefined,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,10 +1293,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/app-data@v0.1.0-alpha.0":
-  version "0.1.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.1.0-alpha.0.tgz#8499136d025e85494f762784e2e308bb3f88ec17"
-  integrity sha512-Dh6QD+rG1Tcv3mSwAkWv7bWCQVhYaJ0L8R/cqLrkVDwqwaxzBYHXLlnNnqC8IKThwvy9iMGM2hrDrYSAIAf/vA==
+"@cowprotocol/app-data@v0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.1.0.tgz#99a5ac52dcb21044fa11b81cb5a90db2c544e4a6"
+  integrity sha512-E7Fk0LjtCp/TCyEtcudJpY+RqCfdPjlDIkqsLjjGeNd6TeRlZGmZhYXZGT1E4QV75PiMHufdd3WMkTwd7Aufdw==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Summary

Modifies the gateway so we don't depend on Gnosis one any more. 

We default to cloudflare, however, this will be modified by ENV so we use https://ipfs.cow.fi/ipfs

This PR adds the required ENV variable

## Related PR
Related to this PR, i had to do this PR to allow me to modify the IPFS gateway

https://github.com/cowprotocol/app-data/pull/24

##  Technical note
Fixed Elena's reported problem, apparently, it was a non-configurable property, and we were trying to delete it.

If you are curious, I'm using this to check if it can be deleted before doing so
https://github.com/cowprotocol/explorer/pull/475

# To Test
1. Make sure the app-data in the orders is loaded ~using https://ipfs.cow.fi/ipfs~ using Cloudflare (since our gateway has some permission issues

https://explorer-dev-git-ipfs-gateway-cowswap.vercel.app/orders/0x31dda03282cbf2010826c0bd95bc6fcb050969142b6fb8d4f870b6c32a0bf211fbe87d602f7d7dd511349be4acf58842392124a06452a858?tab=overview


![image](https://user-images.githubusercontent.com/2352112/236185467-acd2d44a-dfe1-4f3e-b05a-d3b2e1d3eaf4.png)
