### PR TITLE
fix: fix order price display issue

### DIFF
--- a/src/components/orders/OrderPriceDisplay/index.tsx
+++ b/src/components/orders/OrderPriceDisplay/index.tsx
@@ -20,7 +20,12 @@ const Wrapper = styled.span`
   > span {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  > span > span:first-child {
+    white-space: nowrap;
   }
 
   > span:first-child {
@@ -79,7 +84,8 @@ export function OrderPriceDisplay(props: Props): JSX.Element {
   return (
     <Wrapper>
       <span>
-        {formattedPrice} {quoteSymbol}
+        <span>{formattedPrice}</span>
+        <span>{quoteSymbol}</span>
       </span>
       <span>
         for {baseSymbol}


### PR DESCRIPTION
# Summary

Closes #471

# To test
1. Go to /goerli/orders/0x62baf4be8adec4766d26a2169999cc170c3ead90ae11a28d658e6d75edc05b185b0abe214ab7875562adee331deff0fe1912fe42644d2bb7?tab=fills
2. Invert the price
3. It should show less sign and amount in the same line on small size