### PR TITLE
feat: update internal buffer order graph

### DIFF
--- a/src/api/tenderly/tenderlyApi.ts
+++ b/src/api/tenderly/tenderlyApi.ts
@@ -70,11 +70,14 @@ export function traceToTransfersTrades(trace: Trace): TxTradesAndTransfers {
   try {
     trace.logs.forEach((log) => {
       if (log.name === TypeOfTrace.TRANSFER) {
+        const from = log.inputs[IndexTransferInput.from].value
+        const to = log.inputs[IndexTransferInput.to].value
         transfers.push({
           token: log.raw.address,
-          from: log.inputs[IndexTransferInput.from].value,
-          to: log.inputs[IndexTransferInput.to].value,
+          from,
+          to,
           value: log.inputs[IndexTransferInput.value].value,
+          isInternal: from === to,
         })
       } else if (log.name === TypeOfTrace.TRADE) {
         const trade = {
@@ -93,6 +96,7 @@ export function traceToTransfersTrades(trace: Trace): TxTradesAndTransfers {
             from: log.raw.address,
             to: trade.owner,
             value: trade.buyAmount,
+            isInternal: log.raw.address === trade.owner,
           })
         }
         trades.push(trade)

--- a/src/api/tenderly/tenderlyApi.ts
+++ b/src/api/tenderly/tenderlyApi.ts
@@ -132,19 +132,22 @@ export function accountAddressesInvolved(
 ): Map<string, Account> {
   const result = new Map()
 
+  // Create a set with transfer (to & from) addresses for quicker access
+  const transferAddresses = new Set()
+
+  transfers.forEach((transfer) => {
+    transferAddresses.add(transfer.from)
+    transferAddresses.add(transfer.to)
+  })
+
   try {
-    contracts
-      .filter((contract: Contract) => {
-        // Only usecontracts which are involved in a transfer
-        return transfers.find((transfer) => {
-          return transfer.from === contract.address || transfer.to === contract.address
-        })
-      })
-      .forEach((contract: Contract) => {
+    contracts.forEach((contract: Contract) => {
+      // Only use contracts which are involved in a transfer
+      if (transferAddresses.has(contract.address))
         result.set(contract.address, {
           alias: _contractName(contract.contract_name),
         })
-      })
+    })
     trades.forEach((trade) => {
       // Don't overwrite existing contract alias
       // This addresses an edge case where the settlement contract is also a trader

--- a/src/api/tenderly/types.ts
+++ b/src/api/tenderly/types.ts
@@ -35,6 +35,7 @@ export interface Transfer {
   to: string
   value: string
   token: string
+  isInternal: boolean
 }
 
 export interface Account {

--- a/src/apps/explorer/components/TransanctionBatchGraph/hooks.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/hooks.ts
@@ -56,6 +56,8 @@ export function useCytoscape(params: UseCytoscapeParams): UseCytoscapeReturn {
     [layout.name],
   )
 
+  const stableTxSettlement = JSON.stringify(txSettlement)
+
   useEffect(() => {
     try {
       setFailedToLoadGraph(false)
@@ -73,7 +75,8 @@ export function useCytoscape(params: UseCytoscapeParams): UseCytoscapeReturn {
       console.error(`Failed to build graph`, e)
       setFailedToLoadGraph(true)
     }
-  }, [error, isLoading, txSettlement, networkId, heightSize, resetZoom, layout.name])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error, isLoading, stableTxSettlement, networkId, heightSize, resetZoom, layout.name])
 
   useEffect(() => {
     const cy = cytoscapeRef.current

--- a/src/apps/explorer/components/TransanctionBatchGraph/styled.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/styled.ts
@@ -121,6 +121,7 @@ export function STYLESHEET(theme: DefaultTheme): Stylesheet[] {
         'curve-style': 'bezier',
         'font-size': '15px',
         'text-background-padding': '3px',
+        'control-point-step-size': 75,
       },
     },
     {

--- a/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
@@ -14,6 +14,7 @@ import BigNumber from 'bignumber.js'
 import { APP_NAME } from 'const'
 
 const PROTOCOL_NAME = APP_NAME
+const INTERNAL_NODE_NAME = `${APP_NAME} Buffer`
 
 export interface PopperInstance {
   scheduleUpdate: () => void
@@ -192,7 +193,7 @@ export function getNodes(
 
   txSettlement.transfers.forEach((transfer) => {
     // Custom from id when internal transfer to avoid re-using existing node
-    const fromId = transfer.isInternal ? 'Internal buffer' : transfer.from
+    const fromId = transfer.isInternal ? INTERNAL_NODE_NAME : transfer.from
 
     // If transfer is internal and a node has not been created yet, create one
     if (transfer.isInternal && !internalNodeCreated) {

--- a/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
@@ -204,9 +204,9 @@ export function getNodes(
 
       const account = { alias: fromId }
       builder.node(
-        { type: TypeNodeOnTx.CowProtocol, entity: account, id: fromId },
         // Put it inside the network node
         getNetworkParentNode(account, networkNode.alias),
+        { type: TypeNodeOnTx.Trader, entity: account, id: fromId },
       )
     }
 

--- a/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
@@ -168,7 +168,6 @@ export function getNodes(
       if (!groupNodes.has(receiverNode.alias)) {
         builder.node({ type: TypeNodeOnTx.NetworkNode, entity: receiverNode, id: receiverNode.alias })
         groupNodes.set(receiverNode.alias, account.owner || key)
-        console.log('groupNodes', groupNodes, receiverNode)
       }
       parentNodeName = receiverNode.alias
     }

--- a/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
@@ -134,6 +134,15 @@ function getNetworkParentNode(account: Account, networkName: string): string | u
   return account.alias !== ALIAS_TRADER_NAME ? networkName : undefined
 }
 
+function getInternalParentNode(groupNodes: Map<string, string>, transfer: Transfer): string | undefined {
+  for (const [key, value] of groupNodes) {
+    if (value === transfer.from) {
+      return key
+    }
+  }
+  return undefined
+}
+
 export function getNodes(
   txSettlement: TxSettlement,
   networkId: Network,
@@ -204,9 +213,9 @@ export function getNodes(
 
       const account = { alias: fromId }
       builder.node(
-        // Put it inside the network node
-        getNetworkParentNode(account, networkNode.alias),
         { type: TypeNodeOnTx.Trader, entity: account, id: fromId },
+        // Put it inside the parent node
+        getInternalParentNode(groupNodes, transfer),
       )
     }
 

--- a/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/utils.ts
@@ -147,7 +147,8 @@ export function getNodes(
   const builder = new ElementsBuilder(heightSize)
   builder.node({ type: TypeNodeOnTx.NetworkNode, entity: networkNode, id: networkNode.alias })
 
-  const groupNodes: string[] = []
+  const groupNodes: Map<string, string> = new Map()
+
   for (const key in txSettlement.accounts) {
     const account = txSettlement.accounts[key]
     let parentNodeName = getNetworkParentNode(account, networkNode.alias)
@@ -155,9 +156,10 @@ export function getNodes(
     const receiverNode = { alias: `${abbreviateString(account.owner || key, 4, 4)}-group` }
 
     if (account.owner && account.owner !== key) {
-      if (!groupNodes.includes(receiverNode.alias)) {
+      if (!groupNodes.has(receiverNode.alias)) {
         builder.node({ type: TypeNodeOnTx.NetworkNode, entity: receiverNode, id: receiverNode.alias })
-        groupNodes.push(receiverNode.alias)
+        groupNodes.set(receiverNode.alias, account.owner || key)
+        console.log('groupNodes', groupNodes, receiverNode)
       }
       parentNodeName = receiverNode.alias
     }
@@ -171,9 +173,9 @@ export function getNodes(
       )
 
       if (receivers.includes(key) && account.owner !== key) {
-        if (!groupNodes.includes(receiverNode.alias)) {
+        if (!groupNodes.has(receiverNode.alias)) {
           builder.node({ type: TypeNodeOnTx.NetworkNode, entity: receiverNode, id: receiverNode.alias })
-          groupNodes.push(receiverNode.alias)
+          groupNodes.set(receiverNode.alias, account.owner || key)
         }
         parentNodeName = receiverNode.alias
       }


### PR DESCRIPTION
# Update

Using `CoW Protocol Buffer` as the node name

Moved the node together with the receiver address to be explicit this is a trade

![Screenshot 2023-05-29 at 17 40 35](https://github.com/cowprotocol/explorer/assets/43217/e0fe703d-50bd-49dc-9bb7-df2832332e7c)

# Summary

Part of #491 
Follow up to https://github.com/cowprotocol/explorer/pull/492

Added new node for Internal buffer trades

![image](https://github.com/cowprotocol/explorer/assets/43217/879da927-5a2c-490d-b3c3-28c08ec1d2ab)

Tooltip includes only `from` and `amount`

![image](https://github.com/cowprotocol/explorer/assets/43217/a212721c-8717-418c-acff-8c1bb705632b)


# To Test

1. Open the app and search for the settlement hash `0xd78b614d0d5c39d55c516653e8674b73133d2c9bbdf302e5be036de7c6b304e6`
2. Go to `graph` tab
* It should show a new node named `Internal buffer`
3. Open a regular settlement hash such as `0xa6e62c2713ef08d4e979d8ba63643d6d1f522f8b825c27682098578dd9e1f043`
* It should be displayed as usual, without internal buffers node