### PR TITLE
feat(batch-graph): add link to etherscan to nodes

### DIFF
--- a/src/api/tenderly/tenderlyApi.ts
+++ b/src/api/tenderly/tenderlyApi.ts
@@ -146,6 +146,7 @@ export function accountAddressesInvolved(
       if (transferAddresses.has(contract.address))
         result.set(contract.address, {
           alias: _contractName(contract.contract_name),
+          address: contract.address,
         })
     })
     trades.forEach((trade) => {
@@ -155,6 +156,7 @@ export function accountAddressesInvolved(
       if (!result.has(trade.owner)) {
         result.set(trade.owner, {
           alias: ALIAS_TRADER_NAME,
+          address: trade.owner,
         })
       }
     })
@@ -167,6 +169,7 @@ export function accountAddressesInvolved(
         if (!result.get(address)) {
           result.set(address, {
             alias: abbreviateString(address, 6, 4),
+            address,
           })
         }
       })

--- a/src/api/tenderly/types.ts
+++ b/src/api/tenderly/types.ts
@@ -40,6 +40,8 @@ export interface Transfer {
 
 export interface Account {
   alias: string
+  address?: string
+  href?: string
 }
 
 export interface Contract {

--- a/src/apps/explorer/components/TransanctionBatchGraph/elementsBuilder.tsx
+++ b/src/apps/explorer/components/TransanctionBatchGraph/elementsBuilder.tsx
@@ -35,6 +35,7 @@ export default class ElementsBuilder {
         label: !hideLabel ? node.entity.alias : '',
         type: node.type,
         parent: parent ? `${TypeNodeOnTx.NetworkNode}:${parent}` : undefined,
+        href: node.entity.href,
       },
     }
   }

--- a/src/apps/explorer/components/TransanctionBatchGraph/hooks.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/hooks.ts
@@ -94,6 +94,12 @@ export function useCytoscape(params: UseCytoscapeParams): UseCytoscapeReturn {
     cy.on('mouseout', 'edge', (event): void => {
       event.target.removeClass('hover')
     })
+    cy.on('mouseover', 'node', (event): void => {
+      if (event.target.data('href')) event.target.addClass('hover')
+    })
+    cy.on('mouseout', 'node', (event): void => {
+      event.target.removeClass('hover')
+    })
     cy.nodes().noOverlap({ padding: 5 })
 
     return (): void => {

--- a/src/apps/explorer/components/TransanctionBatchGraph/hooks.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/hooks.ts
@@ -100,6 +100,10 @@ export function useCytoscape(params: UseCytoscapeParams): UseCytoscapeReturn {
     cy.on('mouseout', 'node', (event): void => {
       event.target.removeClass('hover')
     })
+    cy.on('tap', 'node', (event): void => {
+      const href = event.target.data('href')
+      href && window.open(href, '_blank')
+    })
     cy.nodes().noOverlap({ padding: 5 })
 
     return (): void => {

--- a/src/apps/explorer/components/TransanctionBatchGraph/styled.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/styled.ts
@@ -95,7 +95,12 @@ export function STYLESHEET(theme: DefaultTheme): Stylesheet[] {
         'background-color': theme.bg2,
       },
     },
-
+    {
+      selector: 'node[label].hover',
+      style: {
+        color: theme.orange,
+      },
+    },
     {
       selector: 'edge[label]',
       style: {

--- a/src/apps/explorer/components/TransanctionBatchGraph/styled.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/styled.ts
@@ -118,6 +118,7 @@ export function STYLESHEET(theme: DefaultTheme): Stylesheet[] {
         'text-background-shape': 'roundrectangle',
         'font-size': '16px',
         'min-zoomed-font-size': 8,
+        'text-rotation': 'autorotate',
       },
     },
     {
@@ -126,7 +127,6 @@ export function STYLESHEET(theme: DefaultTheme): Stylesheet[] {
         'curve-style': 'bezier',
         'font-size': '15px',
         'text-background-padding': '3px',
-        'control-point-step-size': 75,
       },
     },
     {

--- a/src/components/common/BlockExplorerLink/BlockExplorerLink.tsx
+++ b/src/components/common/BlockExplorerLink/BlockExplorerLink.tsx
@@ -5,8 +5,7 @@ import { ExternalLink } from 'components/analytics/ExternalLink'
 import LogoWrapper, { LOGO_MAP } from 'components/common/LogoWrapper'
 
 import { abbreviateString } from 'utils'
-
-type BlockExplorerLinkType = 'tx' | 'address' | 'contract' | 'token' | 'event'
+import { BlockExplorerLinkType, getExplorerUrl } from 'utils/getExplorerUrl'
 
 export interface Props {
   /**
@@ -38,37 +37,6 @@ export interface Props {
    * to show explorer logo
    */
   showLogo?: boolean
-}
-
-function getEtherscanUrlPrefix(networkId: Network): string {
-  return !networkId || networkId === Network.MAINNET || networkId === Network.GNOSIS_CHAIN
-    ? ''
-    : (Network[networkId] || '').toLowerCase() + '.'
-}
-
-function getEtherscanUrlSuffix(type: BlockExplorerLinkType, identifier: string): string {
-  switch (type) {
-    case 'tx':
-      return `tx/${identifier}`
-    case 'event':
-      return `tx/${identifier}#eventlog`
-    case 'address':
-      return `address/${identifier}`
-    case 'contract':
-      return `address/${identifier}#code`
-    case 'token':
-      return `token/${identifier}`
-  }
-}
-
-function getEtherscanUrl(host: string, networkId: number, type: BlockExplorerLinkType, identifier: string): string {
-  return `https://${getEtherscanUrlPrefix(networkId)}${host}/${getEtherscanUrlSuffix(type, identifier)}`
-}
-
-function getExplorerUrl(networkId: number, type: BlockExplorerLinkType, identifier: string): string {
-  return networkId === Network.GNOSIS_CHAIN
-    ? getEtherscanUrl('gnosisscan.io', networkId, type, identifier)
-    : getEtherscanUrl('etherscan.io', networkId, type, identifier)
 }
 
 /**

--- a/src/hooks/useTxBatchTrades.tsx
+++ b/src/hooks/useTxBatchTrades.tsx
@@ -104,6 +104,7 @@ export function useTxBatchTrades(
         if (!(order.receiver in _accounts)) {
           accountsWithReceiver[order.receiver] = {
             alias: ALIAS_TRADER_NAME,
+            address: order.receiver,
           }
         }
         accountsWithReceiver[order.receiver] = {

--- a/src/hooks/useTxBatchTrades.tsx
+++ b/src/hooks/useTxBatchTrades.tsx
@@ -113,9 +113,9 @@ export function useTxBatchTrades(
           owner: order.owner,
         }
       })
-      Object.values(accountsWithReceiver).forEach(
-        (account) => (account.href = getExplorerUrl(network, 'address', account.address)),
-      )
+      Object.values(accountsWithReceiver).forEach((account) => {
+        if (account.address) account.href = getExplorerUrl(network, 'address', account.address)
+      })
 
       setErc20Addresses(transfersWithKind.map((transfer: Transfer): string => transfer.token))
       setTxBatchTrades({ trades, transfers: transfersWithKind })

--- a/src/hooks/useTxBatchTrades.tsx
+++ b/src/hooks/useTxBatchTrades.tsx
@@ -7,6 +7,7 @@ import { SingleErc20State } from 'state/erc20'
 import { Order } from 'api/operator'
 import BigNumber from 'bignumber.js'
 import { usePrevious } from './usePrevious'
+import { getExplorerUrl } from 'utils/getExplorerUrl'
 
 interface TxBatchTrades {
   trades: Trade[]
@@ -112,6 +113,9 @@ export function useTxBatchTrades(
           owner: order.owner,
         }
       })
+      Object.values(accountsWithReceiver).forEach(
+        (account) => (account.href = getExplorerUrl(network, 'address', account.address)),
+      )
 
       setErc20Addresses(transfersWithKind.map((transfer: Transfer): string => transfer.token))
       setTxBatchTrades({ trades, transfers: transfersWithKind })

--- a/src/utils/getExplorerUrl.ts
+++ b/src/utils/getExplorerUrl.ts
@@ -1,0 +1,34 @@
+import { Network } from 'types'
+
+export type BlockExplorerLinkType = 'tx' | 'address' | 'contract' | 'token' | 'event'
+
+function getEtherscanUrlPrefix(networkId: Network): string {
+  return !networkId || networkId === Network.MAINNET || networkId === Network.GNOSIS_CHAIN
+    ? ''
+    : (Network[networkId] || '').toLowerCase() + '.'
+}
+
+function getEtherscanUrlSuffix(type: BlockExplorerLinkType, identifier: string): string {
+  switch (type) {
+    case 'tx':
+      return `tx/${identifier}`
+    case 'event':
+      return `tx/${identifier}#eventlog`
+    case 'address':
+      return `address/${identifier}`
+    case 'contract':
+      return `address/${identifier}#code`
+    case 'token':
+      return `token/${identifier}`
+  }
+}
+
+function getEtherscanUrl(host: string, networkId: number, type: BlockExplorerLinkType, identifier: string): string {
+  return `https://${getEtherscanUrlPrefix(networkId)}${host}/${getEtherscanUrlSuffix(type, identifier)}`
+}
+
+export function getExplorerUrl(networkId: number, type: BlockExplorerLinkType, identifier: string): string {
+  return networkId === Network.GNOSIS_CHAIN
+    ? getEtherscanUrl('gnosisscan.io', networkId, type, identifier)
+    : getEtherscanUrl('etherscan.io', networkId, type, identifier)
+}


### PR DESCRIPTION
# Summary

Part of #505 

Add on click handler to graph nodes

https://github.com/cowprotocol/explorer/assets/43217/ee4c0324-f714-4eac-8978-590ba8f867ca

# To Test

1. Load a batch view
2. Hover over a node
* Text color should change to orange
3. Click on node
* A new tab to etherscan (or equivalent) should be opened to the respective address