### PR TITLE
chore: don't show fee if its zero

### DIFF
--- a/src/components/orders/GasFeeDisplay/index.tsx
+++ b/src/components/orders/GasFeeDisplay/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Order } from 'api/operator'
 
 import { formatSmartMaxPrecision, safeTokenName } from 'utils'
+import { ZERO_BIG_NUMBER } from 'const'
 
 const Wrapper = styled.div`
   & > span {
@@ -45,7 +46,7 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
         {formattedExecutedFee} {quoteSymbol}
       </span>
       {/* <UsdAmount>(~${totalFeeUSD})</UsdAmount> */}
-      {!fullyFilled && (
+      {!fullyFilled && feeAmount.gt(ZERO_BIG_NUMBER) && (
         <>
           <span>
             of {formattedTotalFee} {quoteSymbol}


### PR DESCRIPTION
# Summary
Fixes https://github.com/cowprotocol/explorer/issues/490

Before:
<img width="735" alt="image" src="https://github.com/cowprotocol/explorer/assets/2352112/40fe1aa3-c414-4cc1-9b24-c057183fde0c">


Now:
<img width="812" alt="image" src="https://github.com/cowprotocol/explorer/assets/2352112/b69717ea-9083-44aa-aba7-f66380e19ca5">


# To Test

Check Order:
`0xb70257e2d9104aaa237e4d6d5b5629b84f3810b3d3966e4936f3b33a855b35f149962bad1fd26051d5bc036603c0d72543333ee9649265d9`

The fee shoud be shown, but not weird messages of `of 0` should be visible