### PR TITLE
fix: fix surplus calculation for very big numbers

### DIFF
--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -150,7 +150,10 @@ function _getPartialFillSellSurplus(params: PartialFillSurplusParams): Surplus |
   const executedBuyAmountBigNumber = new BigNumber(executedBuyAmount)
 
   // BUY is QUOTE
-  const price = buyAmountBigNumber.dividedBy(sellAmountBigNumber)
+  // for some reason, bignumber.js wrongly round very small numbers:
+  // 7152000000 / 4000000000000000000000000000 = 0.00000000000000000179
+  // But native js numbers work fine :)
+  const price = buyAmountBigNumber.toNumber() / sellAmountBigNumber.toNumber()
 
   // What you would get at limit price, in buy token atoms
   const minimumBuyAmount = executedSellAmountBigNumber.multipliedBy(price)

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -141,19 +141,20 @@ type PartialFillSurplusParams = {
   executedBuyAmount: string
 }
 
+// The surplus calculation can be called for huge and small values
+// And default DECIMAL_PLACES=20 is not enough for it and can cause rounding problems
+const BigNumberForSurplus = BigNumber.clone({ DECIMAL_PLACES: 32 })
+
 function _getPartialFillSellSurplus(params: PartialFillSurplusParams): Surplus | null {
   const { buyAmount, sellAmount, executedSellAmountBeforeFees, executedBuyAmount } = params
 
-  const sellAmountBigNumber = new BigNumber(sellAmount)
-  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees)
-  const buyAmountBigNumber = new BigNumber(buyAmount)
-  const executedBuyAmountBigNumber = new BigNumber(executedBuyAmount)
+  const sellAmountBigNumber = new BigNumberForSurplus(sellAmount)
+  const executedSellAmountBigNumber = new BigNumberForSurplus(executedSellAmountBeforeFees)
+  const buyAmountBigNumber = new BigNumberForSurplus(buyAmount)
+  const executedBuyAmountBigNumber = new BigNumberForSurplus(executedBuyAmount)
 
   // BUY is QUOTE
-  // for some reason, bignumber.js wrongly round very small numbers:
-  // 7152000000 / 4000000000000000000000000000 = 0.00000000000000000179
-  // But native js numbers work fine :)
-  const price = buyAmountBigNumber.toNumber() / sellAmountBigNumber.toNumber()
+  const price = buyAmountBigNumber.dividedBy(sellAmountBigNumber)
 
   // What you would get at limit price, in buy token atoms
   const minimumBuyAmount = executedSellAmountBigNumber.multipliedBy(price)
@@ -200,10 +201,10 @@ function _getFillOrKillBuySurplus(order: RawOrder): Surplus | null {
 function _getPartialFillBuySurplus(params: PartialFillSurplusParams): Surplus | null {
   const { buyAmount, sellAmount, executedSellAmountBeforeFees, executedBuyAmount } = params
 
-  const sellAmountBigNumber = new BigNumber(sellAmount)
-  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees)
-  const buyAmountBigNumber = new BigNumber(buyAmount)
-  const executedBuyAmountBigNumber = new BigNumber(executedBuyAmount)
+  const sellAmountBigNumber = new BigNumberForSurplus(sellAmount)
+  const executedSellAmountBigNumber = new BigNumberForSurplus(executedSellAmountBeforeFees)
+  const buyAmountBigNumber = new BigNumberForSurplus(buyAmount)
+  const executedBuyAmountBigNumber = new BigNumberForSurplus(executedBuyAmount)
 
   // SELL is QUOTE
   const price = sellAmountBigNumber.dividedBy(buyAmountBigNumber)


### PR DESCRIPTION
# Summary

For some reason, the surplus is wrongly displayed for very big numbers.

Example: https://explorer.cow.fi/orders/0xe05b6a805656fdf2a4c404be0756f360e0297c53d00371da637a44e133676d2e6cd22a1d90eeba4bfd0080ad9f121d4a33b1fda96459d692?tab=overview

## Background

`bignumber.js` wrongly round very small numbers - when you divide something small to something very big

Actual result:
```
const minimumBuyAmount = new BigNumber('4000000000000000000000000000').multipliedBy(
      (new BigNumber('7152000000'))
        .dividedBy(new BigNumber('4000000000000000000000000000'))
    )
// 7160000000
```

<img width="552" alt="image" src="https://github.com/cowprotocol/explorer/assets/7122625/1ce535da-11e2-4076-b02f-704e3e3bfe55">


Expected result:
```
const minimumBuyAmount = (4000000000000000000000000000) * (7152000000 / 4000000000000000000000000000 )
// 7152000000
```

<img width="491" alt="image" src="https://github.com/cowprotocol/explorer/assets/7122625/eb3516a2-e810-4d2b-86ca-ce5debfbc0c1">

## To test
The displayed surplus should look the same for any other values:
1. Very small
2. Normal
3. Very big