### PR TITLE
Update SDK + Update Subgraph API URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "v0.1.0",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^2.0.6",
+    "@cowprotocol/cow-sdk": "^2.1.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,7 +1377,7 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.4.0.tgz#e93e5f25aac76feeaa348fa57231903274676247"
   integrity sha512-XLs3SlPmXD4lbiWIO7mxxuCn1eE5isuO6EUlE1cj17HqN/wukDAN0xXYPx6umOH/XdjGS33miMiPHELEyY9siw==
 
-"@cowprotocol/cow-sdk@^2.0.6":
+"@cowprotocol/cow-sdk@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.1.0.tgz#b66adf0c4f6d9e6690762a1c3e169db5ba8feff1"
   integrity sha512-/2bM58kddP1um9COO5XNPl88gOmnzAPr8fK6EGsdPkPuAQZtCfOWGvqajTtM+shixA21ZaATcSnNL57s5Zd8qw==


### PR DESCRIPTION
# Summary

Updates the SDK to the latest version

EDIT:  Also changed the env vars to include the new URLs:
https://subgraph.barn.cow.fi/cow
https://subgraph.barn.cow.fi/cow-goerli
https://subgraph.barn.cow.fi/cow-gc

For now we don't have production URLs, these will be used in staging and production


# To Test

~I wouldn't QA test this one, but the follow up where I will add some new URLs for TheGraph~

Adding QA since I added the env vars to use the new endpoints.

Regarding the new URLs, I see we are not getting the right value of volumes and prices for the different tokens in Goerli and Gnosis Chain!  I think this has to do with the deployment! we need to verify the price oracle (probably there's an issue with Uniswap price oracle in the decentralised version for those networks)

Therefore, for the tests, please let's focus on verifying that other things work:
- Mainnet: everything
- Goerli, GC: everything that is not related to price and volume