### PR TITLE
Merge edges for hypernodes + node tooltips

### DIFF
--- a/src/api/tenderly/types.ts
+++ b/src/api/tenderly/types.ts
@@ -35,7 +35,7 @@ export interface Transfer {
   to: string
   value: string
   token: string
-  isInternal: boolean
+  isInternal?: boolean
 }
 
 export interface Account {

--- a/src/apps/explorer/components/TransanctionBatchGraph/elementsBuilder.tsx
+++ b/src/apps/explorer/components/TransanctionBatchGraph/elementsBuilder.tsx
@@ -26,7 +26,7 @@ export default class ElementsBuilder {
     this._countEdgeDirection.set(idDirection, count + 1)
   }
 
-  _createNodeElement = (node: Node, parent?: string, hideLabel?: boolean): ElementDefinition => {
+  _createNodeElement = (node: Node, parent?: string, hideLabel?: boolean, tooltip?: InfoTooltip): ElementDefinition => {
     this._increaseCountNodeType(node.type)
     return {
       group: 'nodes',
@@ -36,6 +36,7 @@ export default class ElementsBuilder {
         label: !hideLabel ? node.entity.alias : '',
         type: node.type,
         parent: parent ? `${TypeNodeOnTx.NetworkNode}:${parent}` : undefined,
+        tooltip,
         href: node.entity.href,
       },
     }
@@ -46,9 +47,9 @@ export default class ElementsBuilder {
     return this
   }
 
-  node(node: Node, parent?: string): this {
+  node(node: Node, parent?: string, tooltip?: InfoTooltip): this {
     const GROUP_NODE_NAME = 'group'
-    this._nodes.push(this._createNodeElement(node, parent, node.id.includes(GROUP_NODE_NAME)))
+    this._nodes.push(this._createNodeElement(node, parent, node.id.includes(GROUP_NODE_NAME), tooltip))
     return this
   }
 

--- a/src/apps/explorer/components/TransanctionBatchGraph/hooks.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/hooks.ts
@@ -116,6 +116,12 @@ export function useCytoscape(params: UseCytoscapeParams): UseCytoscapeReturn {
       event.target.removeClass('hover')
       document.getElementById('tx-graph')?.classList.remove('hover')
     })
+    cy.on('mouseover touchstart', 'node', (event): void => {
+      const target = event.target
+      const targetData: NodeDataDefinition | EdgeDataDefinition = target.data()
+
+      bindPopper(event, targetData, cyPopperRef)
+    })
     cy.on('mouseover', 'node', (event): void => {
       if (event.target.data('href')) {
         event.target.addClass('hover')

--- a/src/apps/explorer/components/TransanctionBatchGraph/nodesBuilder.ts
+++ b/src/apps/explorer/components/TransanctionBatchGraph/nodesBuilder.ts
@@ -278,7 +278,7 @@ export function getNotesAndEdges(
           fromTransfer: sellTransfer,
           toTransfer: buyTransfer,
         })
-      } else if (trade.sellTransfers.length > 1 || trade.buyTransfers.length > 1) {
+      } else if (trade.sellTransfers.length != 1 || trade.buyTransfers.length != 1) {
         // if  there are more than one sellToken or buyToken, the contract becomes a node
         nodes[trade.address] = { address: trade.address, isHyperNode: true }
 

--- a/src/apps/explorer/components/TransanctionBatchGraph/settlementBuilder.tsx
+++ b/src/apps/explorer/components/TransanctionBatchGraph/settlementBuilder.tsx
@@ -113,7 +113,7 @@ export type BuildSettlementParams = {
 }
 
 export function buildTradesBasedSettlement(params: BuildSettlementParams): Settlement | undefined {
-  const { networkId, txData, tokens } = params
+  const { networkId, txData, tokens, orders } = params
   const { trace, contracts } = txData
 
   if (!networkId || !trace || !contracts) {
@@ -121,7 +121,7 @@ export function buildTradesBasedSettlement(params: BuildSettlementParams): Settl
   }
 
   const { trades, transfers } = traceToTransfersAndTrades(trace)
-  const contractTrades = getContractTrades(trades, transfers)
+  const contractTrades = getContractTrades(trades, transfers, orders)
 
   const addressesSet = transfers.reduce((set, transfer) => {
     set.add(getTokenAddress(transfer.token, networkId || 1))


### PR DESCRIPTION
Does multiple things:
- use order information on receiver for creating non-user trades
- merge edges for hypernodes
- show dangeling edges (from minting?); this might be bad idea
- show balances as tooltips

balances for the tooltips are currently computed using edge information. if we leave out edges (eg. from minting) then tooltips should be computed from transfers.