### PR TITLE
fix(percentage-display): improve huge surplus display

### DIFF
--- a/src/components/common/SurplusComponent/index.tsx
+++ b/src/components/common/SurplusComponent/index.tsx
@@ -5,6 +5,7 @@ import { TokenErc20 } from '@gnosis.pm/dex-js'
 import { TokenAmount } from 'components/token/TokenAmount'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { MAX_SURPLUS_PERCENTAGE } from 'const'
 
 const IconWrapper = styled(FontAwesomeIcon)`
   padding: 0 0.5rem 0 0;
@@ -31,6 +32,11 @@ export const Amount = styled.span<{ showHiddenSection: boolean; strechHiddenSect
     `}
 `
 
+const Wrapper = styled.span`
+  display: flex;
+  align-items: center;
+`
+
 export type SurplusComponentProps = {
   surplus: Surplus | null
   token: TokenErc20 | null
@@ -49,13 +55,19 @@ export const SurplusComponent: React.FC<SurplusComponentProps> = (props) => {
 
   const { percentage, amount } = surplus
 
+  const showPercentage = percentage.lt(MAX_SURPLUS_PERCENTAGE)
+
+  const amountDisplay = (
+    <Amount showHiddenSection={!!showHidden || !showPercentage}>
+      <TokenAmount amount={amount} token={token} />
+    </Amount>
+  )
+
   return (
-    <span className={className}>
+    <Wrapper className={className}>
       {icon && <IconWrapper icon={icon} color={iconColor} />}
-      <Percentage>{formatPercentage(percentage)}</Percentage>
-      <Amount showHiddenSection={!!showHidden}>
-        <TokenAmount amount={amount} token={token} />
-      </Amount>
-    </span>
+      <Percentage>{showPercentage ? formatPercentage(percentage) : amountDisplay}</Percentage>
+      {showPercentage && amountDisplay}
+    </Wrapper>
   )
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,7 +1,8 @@
 import BigNumber from 'bignumber.js'
 import BN from 'bn.js'
-import { TokenErc20, UNLIMITED_ORDER_AMOUNT, BATCH_TIME } from '@gnosis.pm/dex-js'
+import { BATCH_TIME, TokenErc20, UNLIMITED_ORDER_AMOUNT } from '@gnosis.pm/dex-js'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
 export {
   UNLIMITED_ORDER_AMOUNT,
   FEE_DENOMINATOR,
@@ -196,3 +197,10 @@ export const IPFS_INVALID_APP_IDS = [
   '0xf6a005bde820da47fdbb19bc07e56782b9ccec403a6899484cf502090627af8a',
   '0x00000000000000000000000055662e225a3376759c24331a9aed764f8f0c9fbb',
 ]
+
+/**
+ * The maximum percentage of the surplus that can be used for the surplus
+ * Values above this will not be displayed.
+ * Instead, the Surplus amount will be used
+ */
+export const MAX_SURPLUS_PERCENTAGE = '1000'

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -2,23 +2,23 @@ import BigNumber from 'bignumber.js'
 import { parseBytes32String } from '@ethersproject/strings'
 import { arrayify } from 'ethers/lib/utils'
 
-import { TokenErc20, formatSmart, safeTokenName } from '@gnosis.pm/dex-js'
+import { formatSmart, safeTokenName, TokenErc20 } from '@gnosis.pm/dex-js'
 
 import {
-  ONE_HUNDRED_BIG_NUMBER,
   BATCH_TIME_IN_MS,
   DEFAULT_DECIMALS,
-  ONE_BIG_NUMBER,
-  TEN_BIG_NUMBER,
   MINIMUM_ATOM_VALUE,
+  ONE_BIG_NUMBER,
+  ONE_HUNDRED_BIG_NUMBER,
+  TEN_BIG_NUMBER,
 } from 'const'
 import {
-  MIDDLE_PRECISION_DECIMALS,
   HIGH_PRECISION_DECIMALS,
   HIGH_PRECISION_SMALL_LIMIT,
+  MIDDLE_PRECISION_DECIMALS,
   NO_ADJUSTMENT_NEEDED_PRECISION,
 } from 'apps/explorer/const'
-import { FormatAmountPrecision, batchIdToDate } from 'utils'
+import { batchIdToDate, FormatAmountPrecision } from 'utils'
 
 export {
   formatSmart,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -156,7 +156,15 @@ export function formatPercentage(percentage: BigNumber): string {
   if (displayPercentage.gt('99.99') && displayPercentage.lt('100')) {
     return '>99.99%'
   }
-  return displayPercentage.decimalPlaces(2, BigNumber.ROUND_FLOOR).toString(10) + '%'
+
+  return (
+    formatSmart({
+      amount: displayPercentage.decimalPlaces(2).toString(),
+      precision: 0,
+      thousandSeparator: false,
+      decimals: 2,
+    }) + '%'
+  )
 }
 
 /**


### PR DESCRIPTION
# Update

On top of that (see below), when surplus percentage > 1000, show the surplus amount instead of percentage

![image](https://github.com/cowprotocol/explorer/assets/43217/5d79ce8c-320f-4318-9a00-c043f7520498)


# Summary

Make huuuge surplus percentages a bit better

From
![image](https://github.com/cowprotocol/explorer/assets/43217/a2285af3-fd12-4294-a3eb-50e33916a4ec)

To
![image](https://github.com/cowprotocol/explorer/assets/43217/c95e059e-f26d-437b-8647-df49ed217baf)

# To Test

1. Check this order `https://explorer.cow.fi/gc/orders/0x46ef40527001b290757c1e55260f806476ed8561852cdcb93122020901d4018cb93bdd291874d637abed0d7b86e31719031b553364adcd5c?tab=overview` and the orders for this address