### PR TITLE
chore: show fullAppData if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@apollo/client": "^3.1.5",
     "@cowprotocol/app-data": "v0.1.0",
     "@cowprotocol/contracts": "1.3.1",
-    "@cowprotocol/cow-sdk": "^2.0.6",
+    "@cowprotocol/cow-sdk": "^2.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",

--- a/src/api/operator/types.ts
+++ b/src/api/operator/types.ts
@@ -18,7 +18,7 @@ export type RawOrder = EnrichedOrder
  */
 export type Order = Pick<
   RawOrder,
-  'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature' | 'class'
+  'owner' | 'uid' | 'appData' | 'kind' | 'partiallyFillable' | 'signature' | 'class' | 'fullAppData'
 > & {
   receiver: string
   txHash?: string

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -194,6 +194,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
     buyToken,
     sellToken,
     appData,
+    fullAppData,
   } = order
 
   if (!buyToken || !sellToken) {
@@ -385,7 +386,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.appData} /> AppData
             </td>
             <td>
-              <DecodeAppData appData={appData} />
+              <DecodeAppData appData={appData} fullAppData={fullAppData ?? undefined} />
             </td>
           </tr>
         </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,10 +1377,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.4.0.tgz#e93e5f25aac76feeaa348fa57231903274676247"
   integrity sha512-XLs3SlPmXD4lbiWIO7mxxuCn1eE5isuO6EUlE1cj17HqN/wukDAN0xXYPx6umOH/XdjGS33miMiPHELEyY9siw==
 
-"@cowprotocol/cow-sdk@^2.0.6":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.1.0.tgz#b66adf0c4f6d9e6690762a1c3e169db5ba8feff1"
-  integrity sha512-/2bM58kddP1um9COO5XNPl88gOmnzAPr8fK6EGsdPkPuAQZtCfOWGvqajTtM+shixA21ZaATcSnNL57s5Zd8qw==
+"@cowprotocol/cow-sdk@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.2.1.tgz#496c7caf3a17e8873e8e4bb4cdbd54b2f966ac1e"
+  integrity sha512-EjvVnfHsM9a/f60msa2MebDQTF7137cIMr/fuCb4K0AdUAsk5NqTrr6fVrp+YMyVrIj9OZ/zhaJUxDfGcwza3w==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
# Summary

Companion PR for https://github.com/cowprotocol/cowswap/pull/2838 of CoW Swap, and https://github.com/cowprotocol/cow-sdk/pull/128 of the SDK

This PR shows the appData when the backend provides it. 

<img width="1172" alt="image" src="https://github.com/cowprotocol/explorer/assets/2352112/53d84664-129e-4f00-88ee-28c492539cd9">


# Technical notes
It doesn't try to get it from IPFS, directly, if available it uses the one returned by the API

# Not included
There's another way to derive the IPFS link now from the appData, however this doesn't work for now until the backend uploads the docs to IPFS.

Once they do we will need to come back and review the logic for generating the IPFS URL, now it will take you to a 404. Leaving this for another PR.

# To Test
1. Check how this order don't show the appData in production/barn/deveopment 0x60e2dd0aca15d6f1c604e35b96f406393aff563d01202eec8bd73db397352aec79063d9173c09887d536924e2f6eadbabac099f564ad372e 
2. How can this PR can show it https://explorer-dev-git-use-fullappdata-cowswap.vercel.app/orders/0x60e2dd0aca15d6f1c604e35b96f406393aff563d01202eec8bd73db397352aec79063d9173c09887d536924e2f6eadbabac099f564ad372e?tab=overview
3. New orders created right now in https://dev.swap.cow.fi/ can only be presented in this PR

# Background

This is part of the changes introduced after CoW Hooks

