### PR TITLE
Hide link to IPFS for new app-datas

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "",
   "dependencies": {
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/app-data": "v1.0.0-rc.4",
+    "@cowprotocol/app-data": "v1.0.0",
     "@cowprotocol/contracts": "1.3.1",
     "@cowprotocol/cow-sdk": "^2.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/src/components/AppData/DecodeAppData.tsx
+++ b/src/components/AppData/DecodeAppData.tsx
@@ -134,9 +134,15 @@ const DecodeAppData = (props: Props): JSX.Element => {
           <RowWithCopyButton
             textToCopy={ipfsUri}
             contentsToDisplay={
-              <a href={ipfsUri} target="_blank" rel="noopener noreferrer">
-                {appData}
-              </a>
+              isLegacyAppDataHex ? (
+                <a href={ipfsUri} target="_blank" rel="noopener noreferrer">
+                  {appData}
+                </a>
+              ) : (
+                // TODO: Remove this, and leave just the LINK after the backend uploads the IPFS documents
+                //  https://cowservices.slack.com/archives/C0375NV72SC/p1689618027267289
+                appData
+              )
             }
           />
         )}

--- a/src/components/AppData/DecodeAppData.tsx
+++ b/src/components/AppData/DecodeAppData.tsx
@@ -130,21 +130,19 @@ const DecodeAppData = (props: Props): JSX.Element => {
       <div className="data-container">
         {appDataError ? (
           <span className="app-data">{appData}</span>
-        ) : (
+        ) : isLegacyAppDataHex ? (
           <RowWithCopyButton
             textToCopy={ipfsUri}
             contentsToDisplay={
-              isLegacyAppDataHex ? (
-                <a href={ipfsUri} target="_blank" rel="noopener noreferrer">
-                  {appData}
-                </a>
-              ) : (
-                // TODO: Remove this, and leave just the LINK after the backend uploads the IPFS documents
-                //  https://cowservices.slack.com/archives/C0375NV72SC/p1689618027267289
-                appData
-              )
+              <a href={ipfsUri} target="_blank" rel="noopener noreferrer">
+                {appData}
+              </a>
             }
           />
+        ) : (
+          // TODO: Remove this, and leave just the LINK after the backend uploads the IPFS documents
+          //  https://cowservices.slack.com/archives/C0375NV72SC/p1689618027267289
+          appData
         )}
         <a className="showMoreAnchor" onClick={(): Promise<void> => handleDecodedAppData(false)}>
           {showDecodedAppData ? '[-] Show less' : '[+] Show more'}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,10 +1369,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/app-data@v1.0.0-rc.4":
-  version "1.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.0-rc.4.tgz#89badc9c30add23aaeed1dc942d0398e6e874833"
-  integrity sha512-lKvuvJu9tnJ41nJr9DgFMUOWofX4gCRhcDpGM+jPYqWv1UY+2CjJSkKxVbrFDS5OKjeHfDLv1Mf0XIMqmNYbkQ==
+"@cowprotocol/app-data@v1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.0.tgz#cca486f5aab6000713cc4871471a47c215c9b97e"
+  integrity sha512-cZYwbgFfM84916qcGxpC6hCoXpwFVpushShNEja7gti0NTHqFbGjcR0Pmyrf4D80QJJeAt9wg+TNa5xy2zCaDQ==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Summary

Workaround for the issue we get when accessing the IPFS file related to orders (404 issue)


The backend has not published yet the documents, so we hide the link until we can show it: https://cowservices.slack.com/archives/C0375NV72SC/p1689618027267289 

We can see the content of the JSON though, its just not in IPFS

# To Test

- Test one of the new app-data: search for order `0x60e2dd0aca15d6f1c604e35b96f406393aff563d01202eec8bd73db397352aec79063d9173c09887d536924e2f6eadbabac099f564ad372e` --> should be not a link

<img width="1041" alt="image" src="https://github.com/cowprotocol/explorer/assets/2352112/f788324c-3ca3-4106-97b3-02bcf40f77e2">


- Test one of the old, it should work as before `0xf547efc5f3f846d0a00ef5346570a8b24d12867f514827d7c9ff26e49584550c8654d1136f2a760ba3e1c9e131cb9ad217921b5264b5c8c7`

<img width="1019" alt="image" src="https://github.com/cowprotocol/explorer/assets/2352112/ce20ef4f-57a1-48d9-ba28-f5f3cc9e82de">

<img width="861" alt="image" src="https://github.com/cowprotocol/explorer/assets/2352112/2f0be156-6872-4347-aa21-b5f2c6182c4b">

