### PR TITLE
Simplify metadata logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "",
   "dependencies": {
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/app-data": "1.0.1-rc.2",
+    "@cowprotocol/app-data": "^1.0.1",
     "@cowprotocol/contracts": "1.3.1",
     "@cowprotocol/cow-sdk": "^2.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "",
   "dependencies": {
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/app-data": "v1.0.1-rc.0",
+    "@cowprotocol/app-data": "1.0.1-rc.2",
     "@cowprotocol/contracts": "1.3.1",
     "@cowprotocol/cow-sdk": "^2.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "",
   "dependencies": {
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/app-data": "v1.0.0",
+    "@cowprotocol/app-data": "v1.0.1-rc.0",
     "@cowprotocol/contracts": "1.3.1",
     "@cowprotocol/cow-sdk": "^2.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -288,8 +288,24 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
                     IPFS CID
                   </a>{' '}
                 </p>
+                )
                 <p>
-                  Use this in your orders <strong>appData</strong> field of CoW Orders.
+                  This CID is derived from the <strong>AppData hex</strong> (
+                  <a
+                    href="https://github.com/cowprotocol/app-data/blob/main/src/api/appDataHexToCid.ts#L30"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    see here how
+                  </a>
+                  ). You can see how this <strong>AppData hex</strong> is encoded, using the{' '}
+                  <a href={'https://cid.ipfs.tech/#' + ipfsHashInfo.cid} target="_blank" rel="noreferrer">
+                    CID Inspector
+                  </a>{' '}
+                </p>
+                <p>
+                  What this means is that you can derived the IPFS CID from on-chain CoW Orders, and download the JSON
+                  from IPFS network to see the meta-information of that order
                 </p>
                 <RowWithCopyButton
                   className="appData-hash"

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -185,10 +185,17 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
     <>
       <div className="info-header box">
         <p>
-          The <strong>appData</strong> is an optional field part of CoW Protocol orders. It allows users/dapps/wallets
-          to attach meta-information to orders. This is useful for giving context to your orders, like crediting the
-          order to a specific UI, adding affiliate information, or even signalling your order should be treated in a
-          special way.
+          The{' '}
+          <a
+            href="https://github.com/cowprotocol/contracts/blob/main/src/contracts/libraries/GPv2Order.sol#L18"
+            target="_blank"
+            rel="noreferrer"
+          >
+            AppData hex
+          </a>
+          is an optional field part of CoW Protocol orders. It allows users/dapps/wallets to attach meta-information to
+          orders. This is useful for giving context to your orders, like crediting the order to a specific UI, adding
+          affiliate information, or even signalling your order should be treated in a special way.
         </p>
         <p>This field is the hexadecimal digest of an IPFS document’s CID of a JSON file.</p>
         <p>

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -131,9 +131,6 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
         resetFormFields('appData')
         setError(undefined)
       }
-      // if (fullAppData !== JSON.stringify(INITIAL_FORM_VALUES)) {
-      //   setDisabledAppData(false)
-      // }
     },
     [ipfsHashInfo],
   )

--- a/src/apps/explorer/pages/AppData/config.tsx
+++ b/src/apps/explorer/pages/AppData/config.tsx
@@ -31,32 +31,8 @@ export const getSchema = async (): Promise<JSONSchema7> => {
   return formatSchema(latestSchema)
 }
 
-// const setDependencies = (formattedSchema: JSONSchema7, field: string, dependencies: { [key: string]: any }): void => {
-//   if (formattedSchema?.properties?.metadata['properties'][field]) {
-//     const requiredFields = formattedSchema.properties.metadata['properties'][field].required
-//     deletePropertyPath(formattedSchema, `properties.metadata.properties.${field}.required`)
-
-//     const properties = formattedSchema.properties.metadata['properties'][field].properties
-//     const [fieldKey] = Object.keys(dependencies)
-//     formattedSchema.properties.metadata['properties'][field].properties = {
-//       [fieldKey]: { type: 'boolean', title: 'Enable/Disable' },
-//     }
-//     dependencies[fieldKey].oneOf[0] = {
-//       properties: {
-//         ...dependencies[fieldKey].oneOf[0].properties,
-//         ...properties,
-//       },
-//       required: requiredFields,
-//     }
-//     formattedSchema.properties.metadata['properties'][field].dependencies = dependencies
-//   }
-// }
-
 const formatSchema = (schema: JSONSchema7): JSONSchema7 => {
   const formattedSchema = structuredClone(schema)
-
-  // setDependencies(formattedSchema, 'quote', quoteDependencies)
-  // setDependencies(formattedSchema, 'referrer', referrerDependencies)
 
   return formattedSchema
 }
@@ -64,7 +40,9 @@ const formatSchema = (schema: JSONSchema7): JSONSchema7 => {
 export const transformErrors = (errors: AjvError[]): AjvError[] => {
   return errors.reduce((errorsList, error) => {
     if (error.name === 'required') {
-      error.message = ERROR_MESSAGES.REQUIRED
+      // Disable the non-required fields (it validates the required fields on un-required fields)
+      // error.message = ERROR_MESSAGES.REQUIRED
+      return errorsList
     } else {
       if (error.property === '.metadata.referrer.address') {
         error.message = ERROR_MESSAGES.INVALID_ADDRESS
@@ -157,7 +135,7 @@ export const decodeAppDataSchema: JSONSchema7 = {
   properties: {
     appData: {
       type: 'string',
-      title: 'AppData',
+      title: 'AppData Hex',
       pattern: '^0x[a-fA-F0-9]{64}',
     },
   },

--- a/src/apps/explorer/pages/AppData/config.tsx
+++ b/src/apps/explorer/pages/AppData/config.tsx
@@ -31,53 +31,34 @@ export const getSchema = async (): Promise<JSONSchema7> => {
   return formatSchema(latestSchema)
 }
 
-const setDependencies = (formattedSchema: JSONSchema7, field: string, dependencies: { [key: string]: any }): void => {
-  if (formattedSchema?.properties?.metadata['properties'][field]) {
-    const requiredFields = formattedSchema.properties.metadata['properties'][field].required
-    deletePropertyPath(formattedSchema, `properties.metadata.properties.${field}.required`)
+// const setDependencies = (formattedSchema: JSONSchema7, field: string, dependencies: { [key: string]: any }): void => {
+//   if (formattedSchema?.properties?.metadata['properties'][field]) {
+//     const requiredFields = formattedSchema.properties.metadata['properties'][field].required
+//     deletePropertyPath(formattedSchema, `properties.metadata.properties.${field}.required`)
 
-    const properties = formattedSchema.properties.metadata['properties'][field].properties
-    const [fieldKey] = Object.keys(dependencies)
-    formattedSchema.properties.metadata['properties'][field].properties = {
-      [fieldKey]: { type: 'boolean', title: 'Enable/Disable' },
-    }
-    dependencies[fieldKey].oneOf[0] = {
-      properties: {
-        ...dependencies[fieldKey].oneOf[0].properties,
-        ...properties,
-      },
-      required: requiredFields,
-    }
-    formattedSchema.properties.metadata['properties'][field].dependencies = dependencies
-  }
-}
+//     const properties = formattedSchema.properties.metadata['properties'][field].properties
+//     const [fieldKey] = Object.keys(dependencies)
+//     formattedSchema.properties.metadata['properties'][field].properties = {
+//       [fieldKey]: { type: 'boolean', title: 'Enable/Disable' },
+//     }
+//     dependencies[fieldKey].oneOf[0] = {
+//       properties: {
+//         ...dependencies[fieldKey].oneOf[0].properties,
+//         ...properties,
+//       },
+//       required: requiredFields,
+//     }
+//     formattedSchema.properties.metadata['properties'][field].dependencies = dependencies
+//   }
+// }
 
 const formatSchema = (schema: JSONSchema7): JSONSchema7 => {
   const formattedSchema = structuredClone(schema)
 
-  setDependencies(formattedSchema, 'quote', quoteDependencies)
-  setDependencies(formattedSchema, 'referrer', referrerDependencies)
+  // setDependencies(formattedSchema, 'quote', quoteDependencies)
+  // setDependencies(formattedSchema, 'referrer', referrerDependencies)
 
   return formattedSchema
-}
-
-export const handleFormatData = (formData: FormProps): any => {
-  if (!formData.metadata || !Object.keys(formData.metadata).length) return formData
-  const formattedData = structuredClone(formData)
-  const isReferrerEnabled = formattedData.metadata.referrer.enableReferrer
-  const isQuoteEnabled = formattedData.metadata.quote.enableQuote
-
-  deletePropertyPath(formattedData, 'metadata.referrer.enableReferrer')
-  deletePropertyPath(formattedData, 'metadata.quote.enableQuote')
-
-  if (!isReferrerEnabled) {
-    deletePropertyPath(formattedData, 'metadata.referrer')
-  }
-  if (!isQuoteEnabled) {
-    deletePropertyPath(formattedData, 'metadata.quote')
-  }
-
-  return formattedData
 }
 
 export const transformErrors = (errors: AjvError[]): AjvError[] => {
@@ -149,36 +130,6 @@ export const deletePropertyPath = (obj: any, path: any): void => {
   if (propConfigurable) {
     delete obj[propName]
   }
-}
-
-const quoteDependencies = {
-  enableQuote: {
-    oneOf: [
-      {
-        properties: {
-          enableQuote: {
-            const: true,
-          },
-        },
-        required: [],
-      },
-    ],
-  },
-}
-
-const referrerDependencies = {
-  enableReferrer: {
-    oneOf: [
-      {
-        properties: {
-          enableReferrer: {
-            const: true,
-          },
-        },
-        required: [],
-      },
-    ],
-  },
 }
 
 export const ipfsSchema: JSONSchema7 = {
@@ -254,20 +205,12 @@ export const uiSchema = {
   },
   metadata: {
     referrer: {
-      version: {
-        'ui:field': 'cField',
-        tooltip: 'The schema will be versioned using Semantic Versioning.',
-      },
       address: {
         'ui:field': 'cField',
         tooltip: 'Add a valid address to enable referrer.',
       },
     },
     quote: {
-      version: {
-        'ui:field': 'cField',
-        tooltip: 'The schema will be versioned using Semantic Versioning.',
-      },
       slippageBips: {
         'ui:field': 'cField',
         tooltip: 'Set the slippage in BIPS (e.g. "0.3").',

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -83,7 +83,7 @@ export const Wrapper = styled(WrapperTemplate)`
     }
     .appData-hash {
       margin: 0 0 1rem 0;
-      max-width: 54rem;
+      max-width: 55rem;
       border: 1px solid ${({ theme }): string => theme.tableRowBorder};
       padding: 0.75rem;
       background: ${({ theme }): string => theme.tableRowBorder};
@@ -136,8 +136,9 @@ export const Wrapper = styled(WrapperTemplate)`
         top: 4rem;
         width: 60rem;
       }
-      h4 {
-        margin: 1rem 0 0.75rem 0;
+      h2 {
+        margin: 2rem 0 2rem 0;
+        font-size: 2rem;
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,11 +53,6 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.21.7.tgz#61caffb60776e49a57ba61a88f02bedd8714f6bc"
   integrity sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==
 
-"@babel/compat-data@^7.22.9":
-  version "7.22.9"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
-  integrity sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==
-
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.22.9":
   version "7.22.9"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
@@ -145,18 +140,7 @@
     "@babel/helper-explode-assignable-expression" "^7.18.6"
     "@babel/types" "^7.18.9"
 
-"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.17.7", "@babel/helper-compilation-targets@^7.18.9", "@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.21.5", "@babel/helper-compilation-targets@^7.22.9":
-  version "7.22.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.9.tgz#f9d0a7aaaa7cd32a3f31c9316a69f5a9bcacb892"
-  integrity sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==
-  dependencies:
-    "@babel/compat-data" "^7.22.9"
-    "@babel/helper-validator-option" "^7.22.5"
-    browserslist "^4.21.9"
-    lru-cache "^5.1.1"
-    semver "^6.3.1"
-
-"@babel/helper-compilation-targets@^7.22.6":
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.17.7", "@babel/helper-compilation-targets@^7.18.9", "@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.21.5", "@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.22.9":
   version "7.22.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.9.tgz#f9d0a7aaaa7cd32a3f31c9316a69f5a9bcacb892"
   integrity sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==
@@ -1369,10 +1353,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/app-data@v1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.0.tgz#cca486f5aab6000713cc4871471a47c215c9b97e"
-  integrity sha512-cZYwbgFfM84916qcGxpC6hCoXpwFVpushShNEja7gti0NTHqFbGjcR0Pmyrf4D80QJJeAt9wg+TNa5xy2zCaDQ==
+"@cowprotocol/app-data@v1.0.1-rc.0":
+  version "1.0.1-rc.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.1-rc.0.tgz#7010537fd3cda8b06bfa779a2ee9998f79255972"
+  integrity sha512-KnlPP8xkjDIztpBmg78h83K0LXmy/AnoonkUdY81cll4S3ySqkRM7PFZTlvEZhL5K2l3uqK67lzvBmNVPP4KNg==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"
@@ -6372,16 +6356,6 @@ browserslist@^4.21.9:
     node-releases "^2.0.12"
     update-browserslist-db "^1.0.11"
 
-browserslist@^4.21.9:
-  version "4.21.9"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.9.tgz#e11bdd3c313d7e2a9e87e8b4b0c7872b13897635"
-  integrity sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==
-  dependencies:
-    caniuse-lite "^1.0.30001503"
-    electron-to-chromium "^1.4.431"
-    node-releases "^2.0.12"
-    update-browserslist-db "^1.0.11"
-
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -6719,11 +6693,6 @@ caniuse-lite@^1.0.30001400:
   version "1.0.30001441"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz#987437b266260b640a23cd18fbddb509d7f69f3e"
   integrity sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==
-
-caniuse-lite@^1.0.30001503:
-  version "1.0.30001516"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz#621b1be7d85a8843ee7d210fd9d87b52e3daab3a"
-  integrity sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==
 
 caniuse-lite@^1.0.30001503:
   version "1.0.30001516"
@@ -8461,11 +8430,6 @@ electron-to-chromium@^1.4.251:
   version "1.4.284"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
-
-electron-to-chromium@^1.4.431:
-  version "1.4.461"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.461.tgz#6b14af66042732bf883ab63a4d82cac8f35eb252"
-  integrity sha512-1JkvV2sgEGTDXjdsaQCeSwYYuhLRphRpc+g6EHTFELJXEiznLt3/0pZ9JuAOQ5p2rI3YxKTbivtvajirIfhrEQ==
 
 electron-to-chromium@^1.4.431:
   version "1.4.461"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,10 +1353,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/app-data@v1.0.1-rc.0":
-  version "1.0.1-rc.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.1-rc.0.tgz#7010537fd3cda8b06bfa779a2ee9998f79255972"
-  integrity sha512-KnlPP8xkjDIztpBmg78h83K0LXmy/AnoonkUdY81cll4S3ySqkRM7PFZTlvEZhL5K2l3uqK67lzvBmNVPP4KNg==
+"@cowprotocol/app-data@1.0.1-rc.2":
+  version "1.0.1-rc.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.1-rc.2.tgz#32b7809260ad641b36bfe27a7387483d2edd813b"
+  integrity sha512-Es2BtDfdHNi+ZTVwFU4Y/e5bhyoekGXgcy0pbX7aXy3PV3EFmMPruu9FwqH3WuRMf5ym31pvJRtND8TACzru6w==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,10 +1353,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/app-data@1.0.1-rc.2":
-  version "1.0.1-rc.2"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.1-rc.2.tgz#32b7809260ad641b36bfe27a7387483d2edd813b"
-  integrity sha512-Es2BtDfdHNi+ZTVwFU4Y/e5bhyoekGXgcy0pbX7aXy3PV3EFmMPruu9FwqH3WuRMf5ym31pvJRtND8TACzru6w==
+"@cowprotocol/app-data@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.1.tgz#ca1d1490b50f83018496f78da3c47cd4e127029e"
+  integrity sha512-vDjLEvlAzdPzn/wlXwreCopuzU+U58MuLmQp40PEaH4rAgLUh9msyB21PkuRgdSAof0WAoptA8/UYFKJ4pW1sg==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Summary
Related to https://github.com/cowprotocol/app-data/pull/32

Since i was working on the app-data, and did some simplifications on the library, i took this chance to remove some weird logic from the DOC generation.

This code is still messy, but at least it should work more automatically out of the box when we add new meta-data. 

This PRs adds the UTM codes, order class, and all the missing types:


## TLDR
Turns this
<img width="1211" alt="image" src="https://github.com/cowprotocol/app-data/assets/2352112/f7db8f4c-d0b9-4dda-ace1-156c76f67e86">


Into this:

<img width="967" alt="image" src="https://github.com/cowprotocol/app-data/assets/2352112/37952bc2-6ed3-4907-ad0c-512d564bf630">


## DEMO

https://github.com/cowprotocol/explorer/assets/2352112/22e72188-2588-4cbc-b33b-3a480ccbb75a



## Adds Prettied + Actual FullAppData + AppData hex + CID
Just for completeness adds all of that, and give some context on what is each.

It tried to be interactive, so you experiment to change some fields

## Dinamic 
Also makes it dynamic (you don't need to send the form, it will update automatically)

This way, you see right away how changing some parameters affects the result


## Improved validation
I suppressed some annoying "required" errors you get because of the metadata and how this library work. 

## Removing the annoying "enable field"
It was super bad UX to enable fields in order to use them.

Also, because this was done programmatically, it was making it hard to add new metadata. You will need to handle the logic of enabling those too. 







# Test
Compare this PR and PRO:
- PR: https://explorer-dev-git-simplify-doc-gen-cowswap.vercel.app/appdata?tab=encode
- PROD: https://explorer.cow.fi/appdata?tab=encode