### PR TITLE
Handle appData errors

### DIFF
--- a/getWebpackConfig.js
+++ b/getWebpackConfig.js
@@ -158,9 +158,6 @@ function getWebpackConfig({ apps = [], config = {}, envVars = {}, defineVars = {
   assert(templatePath, '"templatePath" missing in config')
   assert(logoPath, '"logoPath" missing in config')
 
-  // Log the apps
-  console.log('apps', apps)
-
   // Generate one entry point per app
   const entryPoints = apps.reduce((acc, app) => {
     const { name } = app

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "",
   "dependencies": {
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/app-data": "^1.0.1",
+    "@cowprotocol/app-data": "^1.0.2",
     "@cowprotocol/contracts": "1.3.1",
     "@cowprotocol/cow-sdk": "^2.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -239,7 +239,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
             <p>
               This is the generated and <strong>prettified</strong> file based on the input you provided on the form.
             </p>
-            <p>This content is for illustration porpouses, see below </p>
+            <p>This content is for illustration porpouses, see below.</p>
             <JsonContent content={fullAppDataPrettified} isError={!isValidAppData} />
             {fullAppData && (
               <>
@@ -253,7 +253,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
                   <a href="https://www.npmjs.com/package/json-stringify-deterministic" target="_blank" rel="noreferrer">
                     deterministic JSON formatter
                   </a>{' '}
-                  , this way the same content yields always the same <strong>AppData hex</strong>
+                  , this way the same content yields always the same <strong>AppData hex</strong>.
                 </p>
                 <JsonContent content={fullAppData} isError={!isValidAppData} />
                 <p className="disclaimer">Note: Don’t forget to upload this file to IPFS!</p>
@@ -286,9 +286,9 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
                   This is the{' '}
                   <a href="https://docs.ipfs.tech/concepts/content-addressing/" target="_blank" rel="noreferrer">
                     IPFS CID
-                  </a>{' '}
+                  </a>
+                  .
                 </p>
-                )
                 <p>
                   This CID is derived from the <strong>AppData hex</strong> (
                   <a
@@ -301,11 +301,12 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
                   ). You can see how this <strong>AppData hex</strong> is encoded, using the{' '}
                   <a href={'https://cid.ipfs.tech/#' + ipfsHashInfo.cid} target="_blank" rel="noreferrer">
                     CID Inspector
-                  </a>{' '}
+                  </a>
+                  .
                 </p>
                 <p>
                   What this means is that you can derived the IPFS CID from on-chain CoW Orders, and download the JSON
-                  from IPFS network to see the meta-information of that order
+                  from IPFS network to see the meta-information of that order.
                 </p>
                 <RowWithCopyButton
                   className="appData-hash"

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -185,8 +185,6 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
   //   [appDataForm, ipfsHashInfo],
   // )
 
-  console.log('isValidAppData', { isValidAppData, ipfsHashInfo })
-
   return (
     <>
       <div className="info-header box">

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -114,7 +114,10 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
       })
       // Update CID
       .then(setIpfsHashInfo)
-      .catch((e) => setError(e.message))
+      .catch((e) => {
+        console.error('Error updating the IPFS Hash info (CID, hex)', e)
+        setError(e.message)
+      })
       .finally(() => {
         setIsLoading(false)
         toggleInvalid({ appData: true })
@@ -182,7 +185,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
   //   [appDataForm, ipfsHashInfo],
   // )
 
-  console.log('isValidAppData', { isValidAppData })
+  console.log('isValidAppData', { isValidAppData, ipfsHashInfo })
 
   return (
     <>

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -3,6 +3,7 @@ import { ContentCard as Content, Wrapper as WrapperTemplate } from 'apps/explore
 import { media } from 'theme/styles/media'
 import AppDataWrapper from 'components/common/AppDataWrapper'
 import ExplorerTabs from 'apps/explorer/components/common/ExplorerTabs/ExplorerTabs'
+import { transparentize } from 'polished'
 
 export const StyledExplorerTabs = styled(ExplorerTabs)`
   margin: 1.6rem auto 0;
@@ -70,6 +71,10 @@ export const Wrapper = styled(WrapperTemplate)`
       }
       ${media.mobile} {
         max-width: none;
+      }
+
+      &.error {
+        background: ${({ theme }): string => transparentize(0.8, theme.red1)};
       }
     }
     .hidden-content {
@@ -306,6 +311,10 @@ export const Wrapper = styled(WrapperTemplate)`
         position: initial;
       }
     }
+  }
+
+  span.error {
+    color: ${(props): string => props.theme.red1};
   }
 `
 export const IpfsWrapper = styled.div`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,10 +1353,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/app-data@^1.0.2-rc.1":
-  version "1.0.2-rc.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.2-rc.1.tgz#5f86bc84077c7c7538bc3e26c0af7b445cdde79d"
-  integrity sha512-6IMSZ4oVnSzzuvzfJCIph8Hibbhjs3q4O4Shm94sqJlnmJJca/uPXnu2FK2OHNB120yaNhGzYvarm4gnN974+A==
+"@cowprotocol/app-data@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.2.tgz#e559ed892265b84d926a5c84ce6add14e597bb57"
+  integrity sha512-tf4KGK+moHEAjgmOQ8E7MaRHM/rscbzFxsLE/Q+bLXNYcrcwmFDn/VjahkO7bMWhDQj4whmdgw8rbHlPo7zjdw==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,10 +1353,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/app-data@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.1.tgz#ca1d1490b50f83018496f78da3c47cd4e127029e"
-  integrity sha512-vDjLEvlAzdPzn/wlXwreCopuzU+U58MuLmQp40PEaH4rAgLUh9msyB21PkuRgdSAof0WAoptA8/UYFKJ4pW1sg==
+"@cowprotocol/app-data@^1.0.2-rc.1":
+  version "1.0.2-rc.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.2-rc.1.tgz#5f86bc84077c7c7538bc3e26c0af7b445cdde79d"
+  integrity sha512-6IMSZ4oVnSzzuvzfJCIph8Hibbhjs3q4O4Shm94sqJlnmJJca/uPXnu2FK2OHNB120yaNhGzYvarm4gnN974+A==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Summary

Closes #560

Handles the errors when generating the app-data CID/HEX

This is how it looks when the codes can be generated (valid input)
<img width="1228" alt="image" src="https://github.com/cowprotocol/explorer/assets/2352112/ed461e19-13cb-4e05-b362-6daddf484efc">


This is when you add something illegal in the JSON:
<img width="1270" alt="image" src="https://github.com/cowprotocol/explorer/assets/2352112/437498c4-f6e2-4adf-b6d6-9da99596bfcb">

## Bonus
Adds the latest app-data LIB version, which solves a concurrency issue that was braking the app (not loading the CID/hex on the first load)

https://github.com/cowprotocol/app-data/pull/33

# To Test

1. Test to add an invalid Referrer address  (like `asdfgh` instead of an address)