### PR TITLE
chore: fix issue with rpc provider

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build Project Artifacts
         run: >
+          ETH_NODE_URL: ${{ secrets.ETH_NODE_URL }}
+          INFURA_ID: ${{ secrets.INFURA_ID }}
           REACT_APP_IPFS_READ_URI=${{ secrets.REACT_APP_IPFS_READ_URI }}
           REACT_APP_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
           REACT_APP_SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -57,7 +57,7 @@ dexPriceEstimator:
     - networkId: 100
       url_production: https://dex-price-estimator.xdai.gnosis.io
       url_develop: https://price-estimate-xdai.dev.gnosisdev.com
-      
+
 # Subgraph abstraction, used for getting the last price
 theGraphApi:
   type: 'the-graph' # choices: the-graph
@@ -76,7 +76,7 @@ defaultProviderConfig:
   type: 'infura' # Choices: infura | url
   config:
     # It'll be appended to `infuraEndpoint`
-    infuraId: e941376b017d4dada26dc7891456fa3b
+    infuraId: 2af29cd5ac554ae3b8d991afe1ba4b7d
     infuraEndpoint: wss://mainnet.infura.io/ws/v3/
   #
   # Example for type `url`
@@ -184,7 +184,7 @@ initialTokenList:
     decimals: 18
     addressByNetwork:
       '1': '0x0000000000085d4780B73119b644AE5ecd22b376'
-      '4': '0x0000000000085d4780B73119b644AE5ecd22b376'      
+      '4': '0x0000000000085d4780B73119b644AE5ecd22b376'
 
   - id: 4
     name: USD Coin
@@ -297,7 +297,7 @@ initialTokenList:
     decimals: 18
     addressByNetwork:
       '1': '0x0ae055097c6d159879521c384f1d2123d1f195e6'
-      '100': '0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e'      
+      '100': '0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e'
 
   - id: 21
     name: Wrapped xDAI
@@ -305,7 +305,6 @@ initialTokenList:
     decimals: 18
     addressByNetwork:
       '100': '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
-        
 
   - id: 0
     name: OWL

--- a/playwright/utils/provider_setup.ts
+++ b/playwright/utils/provider_setup.ts
@@ -6,8 +6,7 @@ import { compileInjects, fileExists } from './build_injects'
 import { INFURA_ID } from 'const'
 
 // get connection data from CONFIG
-const { config } = CONFIG.defaultProviderConfig
-const providerURL = 'ethNodeUrl' in config ? config.ethNodeUrl : 'https://rinkeby.infura.io/v3/' + INFURA_ID
+const providerURL = 'https://rinkeby.infura.io/v3/' + INFURA_ID
 
 declare global {
   interface Window {

--- a/playwright/utils/provider_setup.ts
+++ b/playwright/utils/provider_setup.ts
@@ -3,10 +3,11 @@ import Web3EthAccounts, { Accounts as AccountsType } from 'web3-eth-accounts'
 
 import { context } from './test_setup'
 import { compileInjects, fileExists } from './build_injects'
+import { INFURA_ID } from 'const'
 
 // get connection data from CONFIG
 const { config } = CONFIG.defaultProviderConfig
-const providerURL = 'ethNodeUrl' in config ? config.ethNodeUrl : 'https://rinkeby.infura.io/v3/' + config.infuraId
+const providerURL = 'ethNodeUrl' in config ? config.ethNodeUrl : 'https://rinkeby.infura.io/v3/' + INFURA_ID
 
 declare global {
   interface Window {
@@ -14,7 +15,7 @@ declare global {
   }
 }
 // workaround for wrong types
-const accountCreator = new ((Web3EthAccounts as unknown) as typeof AccountsType)()
+const accountCreator = new (Web3EthAccounts as unknown as typeof AccountsType)()
 // random account
 export const account = accountCreator.create()
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ const EXPLORER_APP = {
   title: 'CoW Protocol Explorer',
   filename: 'index.html',
   envVars: {
+    ETH_NODE_URL: process.env.ETH_NODE_URL,
     INFURA_ID: process.env.INFURA_ID,
 
     EXPLORER_APP_DOMAIN_REGEX_DEV:


### PR DESCRIPTION
# Summary

This PR fixes 2 issues:
- Make sure our infura key is used with the InfuraProvider. Before it was using the config file even if you override with an env
- For playwrite tests, we shouldn't use the rpcUrl (because that points to mainnet and not rinkeby). Leaving infura as we currently depend on having the ID setup (we have an infura provider in some other part of the app)
- Pass the ETH_NODE_URL to the app (in webpack)
- Pass ETH_NODE_URL and INFURA_ID during vercel build
- Replaces the public infura key with one we control, and has limitations on number of requests and rate limit: see https://github.com/cowprotocol/cowswap/pull/3187 (companion PR)

# To Test
Hopefully now we use NodeReal for mainnet RPC, and we use the right infura key for the infura provider.