### PR TITLE
feat(app-data): upgrade to latest appData version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "",
   "dependencies": {
     "@apollo/client": "^3.1.5",
-    "@cowprotocol/app-data": "^1.0.2",
+    "@cowprotocol/app-data": "^1.1.0",
     "@cowprotocol/contracts": "1.3.1",
     "@cowprotocol/cow-sdk": "^2.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -8,13 +8,13 @@ import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import AppDataWrapper from 'components/common/AppDataWrapper'
 
 import {
-  INITIAL_FORM_VALUES,
-  getSchema,
-  transformErrors,
-  handleErrors,
-  uiSchema,
   CustomField,
   FormProps,
+  getSchema,
+  handleErrors,
+  INITIAL_FORM_VALUES,
+  transformErrors,
+  uiSchema,
 } from './config'
 import { TabData } from '.'
 import { metadataApiSDK } from 'cowSdk'

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -201,7 +201,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
           orders. This is useful for giving context to your orders, like crediting the order to a specific UI, adding
           affiliate information, or even signalling your order should be treated in a special way.
         </p>
-        <p>This field is the hexadecimal digest of an IPFS document’s CID of a JSON file.</p>
+        <p>This field is the hexadecimal digest of a JSON file.</p>
         <p>
           The JSON file follows a
           <a target="_blank" href="https://json-schema.org" rel="noreferrer">

--- a/src/apps/explorer/pages/AppData/EncodePage.tsx
+++ b/src/apps/explorer/pages/AppData/EncodePage.tsx
@@ -402,7 +402,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
         {error && !isDocUploaded && (
           <Notification type="error" message={error} closable={false} appendMessage={false} />
         )}
-      </div> 
+      </div>
       */}
     </>
   )

--- a/src/apps/explorer/pages/AppData/config.tsx
+++ b/src/apps/explorer/pages/AppData/config.tsx
@@ -17,10 +17,10 @@ export const INITIAL_FORM_VALUES = {
   metadata: {},
 }
 
-export const INVALID_IPFS_CREDENTIALS = [
-  'Type error',
-  "Failed to execute 'setRequestHeader' on 'XMLHttpRequest': String contains non ISO-8859-1 code point.",
-]
+// export const INVALID_IPFS_CREDENTIALS = [
+//   'Type error',
+//   "Failed to execute 'setRequestHeader' on 'XMLHttpRequest': String contains non ISO-8859-1 code point.",
+// ]
 
 export type FormProps = Record<string, any>
 
@@ -110,22 +110,22 @@ export const deletePropertyPath = (obj: any, path: any): void => {
   }
 }
 
-export const ipfsSchema: JSONSchema7 = {
-  type: 'object',
-  required: ['pinataApiKey', 'pinataApiSecret'],
-  properties: {
-    pinataApiKey: {
-      type: 'string',
-      title: 'Pinata API key',
-      description: 'Add your Pinata API key.',
-    },
-    pinataApiSecret: {
-      type: 'string',
-      title: 'Pinata API secret',
-      description: 'Add your Pinata API secret.',
-    },
-  },
-}
+// export const ipfsSchema: JSONSchema7 = {
+//   type: 'object',
+//   required: ['pinataApiKey', 'pinataApiSecret'],
+//   properties: {
+//     pinataApiKey: {
+//       type: 'string',
+//       title: 'Pinata API key',
+//       description: 'Add your Pinata API key.',
+//     },
+//     pinataApiSecret: {
+//       type: 'string',
+//       title: 'Pinata API secret',
+//       description: 'Add your Pinata API secret.',
+//     },
+//   },
+// }
 
 export const decodeAppDataSchema: JSONSchema7 = {
   type: 'object',
@@ -197,13 +197,13 @@ export const uiSchema = {
   },
 }
 
-export const ipfsUiSchema = {
-  pinataApiKey: {
-    'ui:field': 'cField',
-    tooltip: 'Add your Pinata API key.',
-  },
-  pinataApiSecret: {
-    'ui:field': 'cField',
-    tooltip: 'Add your Pinata API secret key.',
-  },
-}
+// export const ipfsUiSchema = {
+//   pinataApiKey: {
+//     'ui:field': 'cField',
+//     tooltip: 'Add your Pinata API key.',
+//   },
+//   pinataApiSecret: {
+//     'ui:field': 'cField',
+//     tooltip: 'Add your Pinata API secret key.',
+//   },
+// }

--- a/src/apps/explorer/pages/AppData/styled.ts
+++ b/src/apps/explorer/pages/AppData/styled.ts
@@ -119,6 +119,25 @@ export const Wrapper = styled(WrapperTemplate)`
       line-height: 1.6rem;
     }
 
+    i.glyphicon {
+      display: none;
+    }
+    .btn-add::after {
+      content: 'Add';
+    }
+    .array-item-copy::after {
+      content: 'Copy';
+    }
+    .array-item-move-up::after {
+      content: 'Move Up';
+    }
+    .array-item-move-down::after {
+      content: 'Move Down';
+    }
+    .array-item-remove::after {
+      content: 'Remove';
+    }
+
     .hidden-content {
       ${media.desktop} {
         position: sticky;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/app-data@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.0.2.tgz#e559ed892265b84d926a5c84ce6add14e597bb57"
-  integrity sha512-tf4KGK+moHEAjgmOQ8E7MaRHM/rscbzFxsLE/Q+bLXNYcrcwmFDn/VjahkO7bMWhDQj4whmdgw8rbHlPo7zjdw==
+"@cowprotocol/app-data@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-1.1.0.tgz#38d91a79388220bc1ff99d2b6d0d3e3cce38e8f9"
+  integrity sha512-r55wyVrVnyq32KcswGN+1q5jTIfkLq4NlhibLWpe8px05lqvHA/RXRLO8lTkK7WFtlbO4iSnQqkIs4wqLc80kg==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Update 2023-10-31

After lots of digging, found out what I needed to update: https://rjsf-team.github.io/react-jsonschema-form/docs/advanced-customization/internals/#custom-array-field-buttons

Now we have add, remove, move up/down buttons!
![image](https://github.com/cowprotocol/explorer/assets/43217/b6336b30-4a12-43f2-bd6c-b756c975c8bf)


# Summary

Upgrade to latest appData version 1.1.0

It contains the new metadata fields: `hooks` and `signer`

![image](https://github.com/cowprotocol/explorer/assets/43217/b65804a9-adaf-4763-b88d-8cc91f46efab)

![image](https://github.com/cowprotocol/explorer/assets/43217/4817db05-3547-4fd4-bcb2-b060cb160e86)

# To Test

1. From the menu, navigate to the appData tab: 
![image](https://github.com/cowprotocol/explorer/assets/43217/9abfcb14-59a5-4350-8f45-153f35a573f5)
2. You should see the new metadata fields on the left side form.

# Notes

1. CSS seems a bit broken, I can't investigate this now
2. There might be more work required, I also have not tried this too hard