### PR TITLE
fix: fix order surplus percentage calculation

### DIFF
--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -193,7 +193,7 @@ function _getFillOrKillBuySurplus(order: RawOrder): Surplus | null {
   // The difference between `sellAmount - executedSellAmount` is the surplus.
   const amount = sellAmountBigNumber.minus(executedSellAmountBigNumber)
 
-  const percentage = amount.dividedBy(sellAmountBigNumber)
+  const percentage = amount.dividedBy(executedSellAmountBigNumber)
 
   return { amount, percentage }
 }
@@ -213,7 +213,7 @@ function _getPartialFillBuySurplus(params: PartialFillSurplusParams): Surplus | 
 
   const amount = maximumSellAmount.minus(executedSellAmountBigNumber)
 
-  const percentage = amount.dividedBy(maximumSellAmount)
+  const percentage = amount.dividedBy(executedSellAmountBigNumber)
 
   return { amount, percentage }
 }

--- a/src/utils/operator.ts
+++ b/src/utils/operator.ts
@@ -129,7 +129,7 @@ function _getFillOrKillSellSurplus(order: RawOrder): Surplus | null {
 
   const amount = difference.gt(ZERO_BIG_NUMBER) ? difference : ZERO_BIG_NUMBER
 
-  const percentage = amount.dividedBy(buyAmountBigNumber)
+  const percentage = amount.dividedBy(executedBuyAmountBigNumber)
 
   return { amount, percentage }
 }
@@ -164,7 +164,7 @@ function _getPartialFillSellSurplus(params: PartialFillSurplusParams): Surplus |
   const amount = executedBuyAmountBigNumber.minus(minimumBuyAmount)
 
   // The percentage is based on the amount you would receive, if executed at limit price
-  const percentage = amount.dividedBy(minimumBuyAmount)
+  const percentage = amount.dividedBy(executedBuyAmountBigNumber)
 
   return { amount, percentage }
 }

--- a/test/utils/operator/orderSurplus.test.ts
+++ b/test/utils/operator/orderSurplus.test.ts
@@ -9,8 +9,8 @@ import { OrderKind } from '@cowprotocol/cow-sdk'
 
 const ZERO_DOT_ZERO_ONE = new BigNumber('0.01')
 const TEN_PERCENT = new BigNumber('0.1')
-const TWENTY_PERCENT = new BigNumber('0.2')
 const TWENTY_FIVE_PERCENT = new BigNumber('0.25')
+const TWENTY = new BigNumber('20')
 
 describe('getOrderSurplus', () => {
   describe('Buy order', () => {
@@ -39,9 +39,9 @@ describe('getOrderSurplus', () => {
           kind: OrderKind.BUY,
           sellAmount: '100',
           executedBuyAmount: '100',
-          executedSellAmountBeforeFees: '99',
+          executedSellAmountBeforeFees: '80',
         }
-        expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+        expect(getOrderSurplus(order)).toEqual({ amount: TWENTY, percentage: TWENTY_FIVE_PERCENT })
       })
       test('With fees > 0', () => {
         const order = {
@@ -49,10 +49,10 @@ describe('getOrderSurplus', () => {
           kind: OrderKind.BUY,
           sellAmount: '100',
           executedBuyAmount: '100',
-          executedSellAmountBeforeFees: '99',
+          executedSellAmountBeforeFees: '80',
           totalFee: '10',
         }
-        expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+        expect(getOrderSurplus(order)).toEqual({ amount: TWENTY, percentage: TWENTY_FIVE_PERCENT })
       })
     })
     describe('partiallyFillable', () => {
@@ -78,7 +78,7 @@ describe('getOrderSurplus', () => {
           sellAmount: '100',
           executedSellAmountBeforeFees: '40',
         }
-        expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
+        expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_FIVE_PERCENT })
       })
       test('Full match no surplus', () => {
         const order = {
@@ -96,9 +96,9 @@ describe('getOrderSurplus', () => {
           buyAmount: '100',
           executedBuyAmount: '100',
           sellAmount: '100',
-          executedSellAmountBeforeFees: '90',
+          executedSellAmountBeforeFees: '80',
         }
-        expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
+        expect(getOrderSurplus(order)).toEqual({ amount: TWENTY, percentage: TWENTY_FIVE_PERCENT })
       })
     })
   })

--- a/test/utils/operator/orderSurplus.test.ts
+++ b/test/utils/operator/orderSurplus.test.ts
@@ -1,16 +1,16 @@
 import BigNumber from 'bignumber.js'
 
-import { ONE_BIG_NUMBER, TEN_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
+import { TEN_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
 import { getOrderSurplus, ZERO_SURPLUS } from 'utils'
 
 import { RAW_ORDER } from '../../data'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 
-const ZERO_DOT_ZERO_ONE = new BigNumber('0.01')
-const TEN_PERCENT = new BigNumber('0.1')
+const TWENTY_PERCENT = new BigNumber('0.2')
 const TWENTY_FIVE_PERCENT = new BigNumber('0.25')
 const TWENTY = new BigNumber('20')
+const TWENTY_FIVE = new BigNumber('25')
 
 describe('getOrderSurplus', () => {
   describe('Buy order', () => {
@@ -128,20 +128,20 @@ describe('getOrderSurplus', () => {
           ...RAW_ORDER,
           kind: OrderKind.SELL,
           buyAmount: '100',
-          executedBuyAmount: '101',
+          executedBuyAmount: '125',
           executedSellAmountBeforeFees: '100',
         }
-        expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+        expect(getOrderSurplus(order)).toEqual({ amount: TWENTY_FIVE, percentage: TWENTY_PERCENT })
       })
       test('With fees > 0', () => {
         const order = {
           ...RAW_ORDER,
           kind: OrderKind.SELL,
           buyAmount: '100',
-          executedBuyAmount: '101',
+          executedBuyAmount: '125',
           executedSellAmountBeforeFees: '100',
         }
-        expect(getOrderSurplus(order)).toEqual({ amount: ONE_BIG_NUMBER, percentage: ZERO_DOT_ZERO_ONE })
+        expect(getOrderSurplus(order)).toEqual({ amount: TWENTY_FIVE, percentage: TWENTY_PERCENT })
       })
     })
     describe('partiallyFillable', () => {
@@ -171,7 +171,7 @@ describe('getOrderSurplus', () => {
           sellAmount: '100',
           executedSellAmountBeforeFees: '40',
         }
-        expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_FIVE_PERCENT })
+        expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TWENTY_PERCENT })
       })
       test('Full match no surplus', () => {
         const order = {
@@ -187,11 +187,11 @@ describe('getOrderSurplus', () => {
         const order = {
           ...ORDER,
           buyAmount: '100',
-          executedBuyAmount: '110',
+          executedBuyAmount: '125',
           sellAmount: '100',
           executedSellAmountBeforeFees: '100',
         }
-        expect(getOrderSurplus(order)).toEqual({ amount: TEN_BIG_NUMBER, percentage: TEN_PERCENT })
+        expect(getOrderSurplus(order)).toEqual({ amount: TWENTY_FIVE, percentage: TWENTY_PERCENT })
       })
     })
   })


### PR DESCRIPTION
> DRAFT: I actually have some fundamental questions about the surplus calculation. So I will put this a draft until we get an agreement, then I will need to decide about sellOrders (and fix tests)
> https://cowservices.slack.com/archives/C035N0YEB6J/p1703098943291339

# Summary

Surplus for buy orders is broken. 

Look at this example. The numbers match to me on how we define the order:
![image](https://github.com/cowprotocol/explorer/assets/2352112/b8999b5f-435f-46e9-9040-43832d79d44a)


50% slippage, it means in this example we need to add to the sell amount half of the sell amount
in this case `0.049 * 0.5 = 0.0245`

Our buy order max sell amount is `0.0735`

So far so good 😊

Imagine we execute the order, and we get exactly the quote (`0.049`)

The surplus sould be 50%, right?

However the explorer does this:
`(0.049-0.0735)/0.0735 `

So we think surplus is `33.33%`  ❌

**What is the mistake in the explorer??**
I believe we need to divide by the received price, not by the limit price in this case.

`But Order Surplus = How much less I spent / How much I received`

Take this order as an example:
0x1f9b14a849a1a903eab355ae6240cebb7174f4168064014cb46641f02e2d90f779063d9173c09887d536924e2f6eadbabac099f5658318db

https://explorer.cow.fi/gc/orders/0x1f9b14a849a1a903eab355ae6240cebb7174f4168064014cb46641f02e2d90f779063d9173c09887d536924e2f6eadbabac099f5658318db?tab=overview

This PR:
https://explorer-dev-git-fix-surplus-buy-orders-cowswap.vercel.app/gc/orders/0x1f9b14a849a1a903eab355ae6240cebb7174f4168064014cb46641f02e2d90f779063d9173c09887d536924e2f6eadbabac099f5658318db?tab=overview

## context
https://cowservices.slack.com/archives/C0361CDD1FZ/p1703089134101259

## Test

sell/buy orders should work same as before
