### PR TITLE
feat: do not show fee until available

### DIFF
--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -116,7 +116,7 @@ const tooltip = {
     'The (averaged) surplus for this order. This is the positive difference between the initial limit price and the actual (average) execution price.',
   filled:
     'Indicates what percentage amount this order has been filled and the amount sold/bought. Amount sold includes the fee.',
-  fees: 'The amount of fees paid for this order. This will show a progressive number for orders with partial fills.',
+  fees: 'The amount of fees paid for this order. This will show a progressive number for orders with partial fills. Might take a few minutes to show the final value.',
 }
 
 export const Wrapper = styled.div`

--- a/src/components/orders/GasFeeDisplay/index.tsx
+++ b/src/components/orders/GasFeeDisplay/index.tsx
@@ -40,11 +40,12 @@ export function GasFeeDisplay(props: Props): JSX.Element | null {
     quoteSymbol = safeTokenName(sellToken)
   }
 
+  // In case: the order hasn't had any fills OR it had but the fee hasn't been reported yet in the API
+  const noFee = feeAmount.isZero() && totalFee.isZero()
+
   return (
     <Wrapper>
-      <span>
-        {formattedExecutedFee} {quoteSymbol}
-      </span>
+      <span>{noFee ? '-' : `${formattedExecutedFee} ${quoteSymbol}`}</span>
       {/* <UsdAmount>(~${totalFeeUSD})</UsdAmount> */}
       {!fullyFilled && feeAmount.gt(ZERO_BIG_NUMBER) && (
         <>


### PR DESCRIPTION
# Summary

With the fee=0 introduction, SWAP fees will not be known until ~15min after the trade is executed.
(Backend will shorten the time, but still)
In order to not give the wrong impression to users, we should show the fee as `0`.

This change simply replaced the `0` with a `-` while there's no fee.
This is already the case for limit orders but we never realized that...

# To Test

1. Place a limit order
2. Check the order id against this PR
* Fees field should show `-`
3. Once the order trades, check again
* Fees field should still show `-`
![image](https://github.com/cowprotocol/explorer/assets/43217/19066ab4-67b9-4cd2-8358-3ba0c8707486)

4. ~15 min or more after the trade, check again
* Fees field should be populated with the right value