### PR TITLE
feat: classify order types

### DIFF
--- a/src/components/AppData/DecodeAppData.tsx
+++ b/src/components/AppData/DecodeAppData.tsx
@@ -7,6 +7,7 @@ import Spinner from 'components/common/Spinner'
 import { DEFAULT_IPFS_READ_URI, IPFS_INVALID_APP_IDS } from 'const'
 import { appDataHexToCid, fetchDocFromAppDataHex } from 'hooks/useAppData'
 import useSafeState from 'hooks/useSafeState'
+import { decodeFullAppData } from 'utils/decodeFullAppData'
 
 type Props = {
   appData: string
@@ -22,7 +23,7 @@ async function _getDecodedAppData(
   // If the full appData is available, we try to parse it as JSON
   if (fullAppData) {
     try {
-      const decodedAppData = JSON.parse(fullAppData)
+      const decodedAppData = decodeFullAppData(fullAppData, true)
       return { decodedAppData, isError: false }
     } catch (error) {
       console.error('Error parsing fullAppData from the API', { fullAppData }, error)

--- a/src/components/orders/DetailsTable/index.tsx
+++ b/src/components/orders/DetailsTable/index.tsx
@@ -25,6 +25,7 @@ import { sendEvent } from 'components/analytics'
 import { LinkWithPrefixNetwork } from 'components/common/LinkWithPrefixNetwork'
 import DecodeAppData from 'components/AppData/DecodeAppData'
 import { TAB_QUERY_PARAM_KEY } from 'apps/explorer/const'
+import { getUiOrderType } from 'utils/getUiOrderType'
 
 const Table = styled(SimpleTable)`
   > tbody > tr {
@@ -301,7 +302,8 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.type} /> Type
             </td>
             <td>
-              {capitalize(kind)} {order.class} order {partiallyFillable ? '(Partially fillable)' : '(Fill or Kill)'}
+              {capitalize(kind)} {getUiOrderType(order).toLowerCase()} order{' '}
+              {partiallyFillable ? '(Partially fillable)' : '(Fill or Kill)'}
             </td>
           </tr>
           <tr>

--- a/src/utils/decodeFullAppData.ts
+++ b/src/utils/decodeFullAppData.ts
@@ -1,0 +1,28 @@
+import { AnyAppDataDocVersion } from '@cowprotocol/app-data'
+
+/**
+ * Decode appData from a string to a AnyAppDataDocVersion instance
+ * Keep in mind it can be a valid JSON but not necessarily a valid AppDataDoc
+ *
+ * Returns undefined if the given appData is not a valid JSON
+ * When `throwOnError` is true, it will throw an error if the given appData is not a valid JSON
+ */
+export function decodeFullAppData(
+  appData: string | null | undefined,
+  throwOnError?: true,
+): AnyAppDataDocVersion | undefined {
+  if (!appData) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(appData)
+  } catch (e) {
+    if (throwOnError) {
+      throw e
+    }
+
+    console.info('[decodeFullAppData] given appData is not a valid JSON', appData)
+    return undefined
+  }
+}

--- a/src/utils/getUiOrderType.ts
+++ b/src/utils/getUiOrderType.ts
@@ -1,0 +1,43 @@
+import { latest } from '@cowprotocol/app-data'
+import { OrderClass } from '@cowprotocol/cow-sdk'
+import { Order } from 'api/operator'
+import { decodeFullAppData } from 'utils/decodeFullAppData'
+
+/**
+ * UiOrderType based on appData, falling back to backend order class.
+ *
+ * Similar to CoW Swap, but not exactly like it.
+ *
+ * Here, MARKET remains as MARKET, while on CoW Swap it's translated to SWAP.
+ * Also, we keep the LIQUIDITY order type as it, while there it's translated to LIMIT.
+ *
+ * In summary, it matches 1:1 appData.metadata.orderClass.orderClass enum
+ */
+export enum UiOrderType {
+  MARKET = 'MARKET',
+  LIMIT = 'LIMIT',
+  LIQUIDITY = 'LIQUIDITY',
+  TWAP = 'TWAP',
+}
+
+const API_ORDER_CLASS_TO_UI_ORDER_TYPE_MAP: Record<OrderClass, UiOrderType> = {
+  [OrderClass.MARKET]: UiOrderType.MARKET,
+  [OrderClass.LIMIT]: UiOrderType.LIMIT,
+  [OrderClass.LIQUIDITY]: UiOrderType.LIQUIDITY,
+}
+
+export function getUiOrderType({ fullAppData, class: orderClass }: Order): UiOrderType {
+  const appData = decodeFullAppData(fullAppData)
+
+  const appDataOrderClass = appData?.metadata?.orderClass as latest.OrderClass | undefined
+  const typeFromAppData = UiOrderType[appDataOrderClass?.orderClass.toUpperCase() || '']
+
+  // 1. AppData info has priority as it's what's more precise
+  if (typeFromAppData) {
+    return typeFromAppData
+  }
+
+  // 3. Fallback to API classification.
+  // Least precise as it doesn't distinguish twap type and uses backend logic which doesn't match frontend's classification
+  return API_ORDER_CLASS_TO_UI_ORDER_TYPE_MAP[orderClass]
+}


### PR DESCRIPTION
# Summary

Similar to https://github.com/cowprotocol/cowswap/pull/3559
With slight changes:

1. Market type remains market
2. Liquidity type is kept

Adapt the displayed type to be based off appData's orderClass - when available

![image](https://github.com/cowprotocol/explorer/assets/43217/84eb8157-0344-49ad-9393-2296b4eb4c02)

# To Test

1. Open a SWAP fee=0 order, such as `0x984334a5c1edefb49093d3e3530e034425f262638679325c7fb5d9a9b4a7f5775b0abe214ab7875562adee331deff0fe1912fe4265844c6b`
* Order type should be `market`, matching appData; different from api response (which is limit)
1. Open regular SWAP order
* Order type should be `market`, matching appData and api response
2. Open any LIMIT order (they are all fee=0 already)
* Order type should be `limit`, matching appData
3. Open a TWAP part order
* Order type should be `twap`, matching appData; different from api response (which is limit)